### PR TITLE
ebuild-daemon: Handle shutdown command during initialization

### DIFF
--- a/pkgcore/ebuild/eapi-bash/ebuild-daemon.bash
+++ b/pkgcore/ebuild/eapi-bash/ebuild-daemon.bash
@@ -322,6 +322,10 @@ __ebd_process_ebuild_phases()
 			fi
 			cont=2
 			;;
+		shutdown_daemon)
+			echo "ebuild processing aborted" >&2
+			exit 1
+			;;
 		*)
 			echo "received unknown com during phase processing: line was: $line" >&2
 			;;


### PR DESCRIPTION
If there is an error (as in bug) somewhere, we may try to shutdown the
daemon before it finishes the initialization. This change adds handling of
the shutdown command in this case, so no further error occurs and obscures
the debugging.
