### PR TITLE
ebuild: fix encoding of send_env

### DIFF
--- a/pkgcore/ebuild/processor.py
+++ b/pkgcore/ebuild/processor.py
@@ -620,7 +620,7 @@ class EbuildProcessor(object):
         else:
             self.write("set_sandbox_state 0")
 
-    def _generate_env_str(self, env_dict):
+    def _generate_env_data(self, env_dict):
         data = []
         for key, val in env_dict.iteritems():
             if key in self.dont_export_vars:
@@ -628,7 +628,7 @@ class EbuildProcessor(object):
             if not key[0].isalpha():
                 raise KeyError("%s: bash doesn't allow digits as the first char" % (key,))
             if not isinstance(val, basestring):
-                raise ValueError("_generate_env_str was fed a bad value; key=%s, val=%s"
+                raise ValueError("_generate_env_data was fed a bad value; key=%s, val=%s"
                     % (key, val))
             if val.isalnum():
                 data.append("%s=%s" % (key, val))
@@ -636,7 +636,10 @@ class EbuildProcessor(object):
                 data.append("%s='%s'" % (key, val))
             else:
                 data.append("%s=$'%s'" % (key, val.replace("'", "\\'")))
-        return 'export %s' % (' '.join(data),)
+        ret = 'export %s' % (' '.join(data),)
+        if isinstance(ret, unicode):
+            ret = ret.encode('utf-8')
+        return ret
 
     def send_env(self, env_dict, async=False, tmpdir=None):
         """
@@ -645,7 +648,7 @@ class EbuildProcessor(object):
         :type env_dict: mapping with string keys and values.
         :param env_dict: the bash env.
         """
-        data = self._generate_env_str(env_dict)
+        data = self._generate_env_data(env_dict)
         if tmpdir:
             path = osutils.pjoin(tmpdir, 'ebd-env-transfer')
             fileutils.write_file(path, 'wb', data)
@@ -694,7 +697,7 @@ class EbuildProcessor(object):
         self._ensure_metadata_paths(const.HOST_NONROOT_PATHS)
 
         e = expected_ebuild_env(package_inst, depends=True)
-        data = self._generate_env_str(e)
+        data = self._generate_env_data(e)
         self.write("%s %i\n%s" % (command, len(data), data),
             append_newline=False)
 


### PR DESCRIPTION
Please review, I find encodings to be a pretty huge mess and thus am not sure,
that this is the correct solution. However it makes things work on my end.

_generate_env_str returned a unicode string in py3 which needs to be encodod
for serialization. This encodes the string if necessary. Note that ret prior
to encoding may either be bytes or unicode in py2 (it is unicode if data
contains a unicode string).

Rename _generate_env_str to reflect this change.

Note: In the first pull request I missed to delete a debug statement.