### PR TITLE
ebuild-daemon: Exit on spurious commands during ebuild processing

### DIFF
--- a/pkgcore/ebuild/eapi-bash/ebuild-daemon.bash
+++ b/pkgcore/ebuild/eapi-bash/ebuild-daemon.bash
@@ -324,6 +324,7 @@ __ebd_process_ebuild_phases()
 			;;
 		*)
 			echo "received unknown com during phase processing: line was: $line" >&2
+			exit 1
 			;;
 		esac
 	done


### PR DESCRIPTION
We are in an unknown state and thus should abort. One instance is the
command 'shutdown_daemon' which may arrive if there exists a bug causing
failure and thus a shutdown. If we do not exit the backtrace gets
unnecessarily clobbered.