### PR TITLE
vdb: support missing /var/db/pkg dir

### DIFF
--- a/pkgcore/vdb/ondisk.py
+++ b/pkgcore/vdb/ondisk.py
@@ -61,9 +61,10 @@ class tree(prototype.tree):
                 raise errors.InitializationError(
                     "base lacks read/executable: %r" % self.location)
 
-        except OSError:
-            compatibility.raise_from(errors.InitializationError(
-                "lstat failed on base %r" % self.location))
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                compatibility.raise_from(errors.InitializationError(
+                    "lstat failed on base %r" % self.location))
 
         self.package_class = self.package_factory(self)
 

--- a/pkgcore/vdb/virtuals.py
+++ b/pkgcore/vdb/virtuals.py
@@ -63,10 +63,14 @@ def _get_mtimes(loc):
     # yes, listdir here makes sense due to the stating, and the
     # potential for listdir_dirs to do it's own statting if the
     # underlying FS doesn't support dt_type...
-    for x in listdir(loc):
-        st = os.stat(pjoin(loc, x))
-        if sdir(st.st_mode):
-            d[x] = st.st_mtime
+    try:
+        for x in listdir(loc):
+            st = os.stat(pjoin(loc, x))
+            if sdir(st.st_mode):
+                d[x] = st.st_mtime
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
     return d
 
 def _write_mtime_cache(mtimes, data, location):


### PR DESCRIPTION
When testing out an empty root, don't barf when the vdb doesn't exist.