### PR TITLE
Fixed a 'pmerge --clean' behavior by setting replace=False.

### DIFF
--- a/pkgcore/scripts/pmerge.py
+++ b/pkgcore/scripts/pmerge.py
@@ -330,6 +330,7 @@ def _validate(parser, namespace):
                          "targets given")
         namespace.sets = ('world', 'system')
         namespace.deep = True
+        namespace.replace = False
         if namespace.usepkgonly or namespace.usepkg or namespace.source_only:
             parser.error(
                 '--clean cannot be used with any of the following options: '


### PR DESCRIPTION
'clean' should reuse livefs repos.  With replace=True, livefs repos are
excluded by the _vdb_restrict in ebuild/resolver.py, causing the
resolver to generate a packets list that is not consistent with the
installed packets.

The error can be shown by running "pmerge --clean" then "pmerge -uD
@world".  Some packages (automake-1.15 in my case) removed by 'clean'
are reinstalled by 'update'.

Setting replace=False fixed the error.  We don't want to replace
anything by 'pmerge --clean' afterall.