### PR TITLE
Support building with setuptools when available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,18 @@ import os
 import subprocess
 import sys
 
-from distutils import core, log, errors
-from distutils.command import build, build_scripts, install
+try:
+    import setuptools as core
+except ImportError:
+    from distutils import core
+    from distutils.command import install
+else:
+    # we need to use setuptools-specific install command,
+    # otherwise implicit setuptools injection in pip does not work
+    from setuptools.command import install
+
+from distutils import log, errors
+from distutils.command import build, build_scripts
 from distutils.util import byte_compile
 from stat import ST_MODE
 


### PR DESCRIPTION
Import and use setuptools and its 'install' command when available. The setuptools monkey patching done by pip does not replace the install command, therefore the custom install collides with pip otherwise.