### PR TITLE
portage_conf: Do not prepend configroot to md5-cache path

### DIFF
--- a/pkgcore/ebuild/portage_conf.py
+++ b/pkgcore/ebuild/portage_conf.py
@@ -245,7 +245,6 @@ def make_cache(config_root, repo_path):
     if (os.path.exists(pjoin(repo_path, 'metadata', 'md5-cache')) or
             repo_config.cache_format == 'md5-dict'):
         kls = 'pkgcore.cache.flat_hash.md5_cache'
-        repo_path = pjoin(config_root, repo_path.lstrip('/'))
         cache_parent_dir = pjoin(repo_path, 'metadata', 'md5-cache')
     else:
         kls = 'pkgcore.cache.flat_hash.database'


### PR DESCRIPTION
Well, I'm not entirely sure about this one. But how it's done now, it means that it looks for `${repo}/metadata/md5-cache` and then uses `${root}/${repo}/metadata/md5-cache`, which means it doesn't use the actual cache…