### PR TITLE
ebd: set EPREFIX correctly

### DIFF
--- a/pkgcore/ebuild/ebd.py
+++ b/pkgcore/ebuild/ebd.py
@@ -114,7 +114,7 @@ class ebd(object):
         if self.prefix_mode:
             self.env['EROOT'] = normpath(self.domain.root)
             self.prefix = self.domain.prefix.lstrip("/")
-            eprefix = normpath(pjoin(self.env["EROOT"], self.prefix))
+            eprefix = self.prefix
             if eprefix == '/':
                 # Set eprefix to '' if it's basically empty; this keeps certain crappy builds
                 # (cmake for example) from puking over //usr/blah pathways


### PR DESCRIPTION
Set EPREFIX to just the correct prefix as required by the PMS rather
than some normalized combination of EROOT (which is supposed to contain
EPREFIX already...) and the prefix. This fixes non-prefix builds when
ROOT is non-null.