### PR TITLE
Cache fixes

### DIFF
--- a/pkgcore/cache/__init__.py
+++ b/pkgcore/cache/__init__.py
@@ -13,6 +13,7 @@ import os
 import operator
 
 from snakeoil import klass
+from snakeoil.chksum import get_handler
 from snakeoil.compatibility import raise_from
 from snakeoil.mappings import (
     ProtectedDict, autoconvert_py3k_methods_metaclass, make_SlottedDict_kls)
@@ -74,7 +75,7 @@ class base(object):
             return lambda data: '%.0f' % math.floor(data.mtime)
         # Skip the leading 0x...
         getter = operator.attrgetter(chf)
-        return lambda data: hex(getter(data))[2:].rstrip('L')
+        return lambda data: get_handler(chf).long2str(getter(data))
 
     @staticmethod
     def _get_chf_deserializer(chf):

--- a/pkgcore/cache/__init__.py
+++ b/pkgcore/cache/__init__.py
@@ -212,7 +212,7 @@ class base(object):
         """takes a dict, returns a string representing said dict"""
         l = []
         converters = self.eclass_chf_serializers
-        for eclass, data in eclass_dict.iteritems():
+        for eclass, data in sorted(eclass_dict.iteritems()):
             l.append(eclass)
             l.extend(f(data) for f in converters)
         return self.eclass_splitter.join(l)

--- a/pkgcore/cache/flat_hash.py
+++ b/pkgcore/cache/flat_hash.py
@@ -90,7 +90,7 @@ class database(fs_template.FsBased):
         if self._mtime_used:
             if not self.mtime_in_entry:
                 mtime = values['_mtime_']
-        for k, v in values.iteritems():
+        for k, v in sorted(values.iteritems()):
             myf.writelines("%s=%s\n" % (k, v))
 
         myf.close()

--- a/pkgcore/ebuild/ebuild_src.py
+++ b/pkgcore/ebuild/ebuild_src.py
@@ -389,8 +389,6 @@ class package_factory(metadata.factory):
         if inherited:
             mydata["_eclasses_"] = self._ecache.get_eclass_data(
                 inherited.split())
-        else:
-            mydata["_eclasses_"] = {}
         mydata['_chf_'] = chksum.LazilyHashedPath(pkg.path)
 
         for x in wipes:


### PR DESCRIPTION
These two make pkgcore-generated md5-cache useful for Portage. Well, it's not byte-exact still but it seems egencache is happy enough about it not to regenerate the whole cache.