### PR TITLE
sync: Add git+svn syncer

### DIFF
--- a/pkgcore/plugins/pkgcore_syncers.py
+++ b/pkgcore/plugins/pkgcore_syncers.py
@@ -3,5 +3,5 @@
 
 pkgcore_plugins = {
     'syncer': ['pkgcore.sync.%s.%s_syncer' % (x, x) for x in
-               ('bzr', 'cvs', 'darcs', 'git', 'hg', 'svn')],
+               ('bzr', 'cvs', 'darcs', 'git', 'git_svn', 'hg', 'svn')],
 }

--- a/pkgcore/sync/git.py
+++ b/pkgcore/sync/git.py
@@ -22,6 +22,9 @@ class git_syncer(base.dvcs_syncer):
         git_path = os.path.join(path, '.git')
         if cls.disabled or not os.path.isdir(git_path):
             return None
+        # defer to git-svn plugin
+        if os.path.isdir(os.path.join(git_path, 'svn')):
+            return None
         return (cls._rewrite_uri_from_stat(git_path, "git://"),)
 
     @staticmethod

--- a/pkgcore/sync/git_svn.py
+++ b/pkgcore/sync/git_svn.py
@@ -1,0 +1,48 @@
+# vim: set fileencoding=utf-8 :
+# Copyright: 2015 Michał Górny <mgorny@gentoo.org>
+# License: GPL2/BSD
+
+__all__ = ("git_svn_syncer",)
+
+import os
+
+from pkgcore.sync import base
+
+
+class git_svn_syncer(base.dvcs_syncer):
+
+    binary = "git"
+
+    supported_uris = (
+        ('git+svn://', 10),
+        ('git+svn+', 10),
+    )
+
+    @classmethod
+    def is_usable_on_filepath(cls, path):
+        git_svn_path = os.path.join(path, '.git', 'svn')
+        if cls.disabled or not os.path.isdir(git_svn_path):
+            return None
+        return (cls._rewrite_uri_from_stat(git_svn_path, "git+svn://"),)
+
+    @staticmethod
+    def parse_uri(raw_uri):
+        if not raw_uri.startswith("git+svn+") and not raw_uri.startswith("git+svn://"):
+            raise base.uri_exception(
+                raw_uri, "doesn't start with git+svn+ nor git+svn://")
+        if raw_uri.startswith("git+svn+"):
+            if raw_uri.startswith("git+svn+:"):
+                raise base.uri_exception(
+                    raw_uri, "need to specify the sub protocol if using git+svn+")
+            return raw_uri[8:]
+        return raw_uri[4:]
+
+    def __init__(self, basedir, uri, **kwargs):
+        uri = self.parse_uri(uri)
+        base.dvcs_syncer.__init__(self, basedir, uri, **kwargs)
+
+    def _initial_pull(self):
+        return [self.binary_path, "svn", "clone", self.uri, self.basedir]
+
+    def _update_existing(self):
+        return [self.binary_path, "svn", "rebase"]

--- a/pkgcore/test/sync/test_git_svn.py
+++ b/pkgcore/test/sync/test_git_svn.py
@@ -1,0 +1,23 @@
+# vim: set fileencoding=utf-8 :
+# Copyright: 2015 Michał Górny <mgorny@gentoo.org>
+# License: GPL2/BSD
+
+from pkgcore.sync import base, git_svn
+from pkgcore.test import TestCase
+from pkgcore.test.sync import make_bogus_syncer, make_valid_syncer
+
+bogus = make_bogus_syncer(git_svn.git_svn_syncer)
+valid = make_valid_syncer(git_svn.git_svn_syncer)
+
+
+class TestgitsvnParsing(TestCase):
+
+    def test_parse(self):
+        self.assertEqual(git_svn.git_svn_syncer.parse_uri("git+svn+http://dar"),
+            "http://dar")
+        self.assertRaises(base.uri_exception, git_svn.git_svn_syncer.parse_uri,
+            "git+svn+://dar")
+        self.assertRaises(base.syncer_exception, bogus,
+            "/tmp/foon", "git+svn+http://foon.com/dar")
+        o = valid("/tmp/foon", "git+svn+http://dar")
+        self.assertEqual(o.uri, "http://dar")


### PR DESCRIPTION
Add a syncer for git+svn that uses the 'git svn' subcommand to mirror the complete history of a subversion repository.