### PR TITLE
pmaint regen: Clean up stale cache entries

### DIFF
--- a/pkgcore/operations/repo.py
+++ b/pkgcore/operations/repo.py
@@ -222,6 +222,14 @@ class operations(sync_operations):
         return self._cmd_implementation_configure(
             self.repository, pkg, self._get_observer(observer))
 
+    def _cmd_implementation_clean_cache(self):
+        """ Clean stale cache entries up """
+        pkgs = frozenset(x.cpvstr for x in self.repo)
+        for c in self._get_caches():
+            cache_pkgs = frozenset(c.keys())
+            for p in cache_pkgs - pkgs:
+                del c[p]
+
     @_operations_mod.is_standalone
     def _cmd_api_regen_cache(self, observer=None, threads=1, **options):
         if getattr(self, '_regen_disable_threads', False):
@@ -231,9 +239,11 @@ class operations(sync_operations):
         try:
             if sync_rate is not None:
                 cache.set_sync_rate(1000000)
-            return regen.regen_repository(
+            ret = regen.regen_repository(
                 self.repo,
                 self._get_observer(observer), threads=threads, **options)
+            self._cmd_implementation_clean_cache()
+            return ret
         finally:
             if sync_rate is not None:
                 cache.set_sync_rate(sync_rate)

--- a/pkgcore/operations/repo.py
+++ b/pkgcore/operations/repo.py
@@ -224,11 +224,14 @@ class operations(sync_operations):
 
     def _cmd_implementation_clean_cache(self):
         """ Clean stale cache entries up """
+        caches = [x for x in self._get_caches() if not x.readonly]
+        if not caches:
+            return
         pkgs = frozenset(x.cpvstr for x in self.repo)
-        for c in self._get_caches():
-            cache_pkgs = frozenset(c.keys())
+        for cache in caches:
+            cache_pkgs = frozenset(cache)
             for p in cache_pkgs - pkgs:
-                del c[p]
+                del cache[p]
 
     @_operations_mod.is_standalone
     def _cmd_api_regen_cache(self, observer=None, threads=1, **options):


### PR DESCRIPTION
As the summary says. I have used the simplest solution possible, and it seems not to cause any significant slowdown.

One small issue is that cache entries for broken packages are not removed but that's more of a corner case to handle.