### PR TITLE
spawn: Ensure that SANDBOX_BINARY is actually Gentoo sandbox

### DIFF
--- a/pkgcore/spawn.py
+++ b/pkgcore/spawn.py
@@ -480,6 +480,12 @@ def is_sandbox_capable(force=False):
         except AttributeError:
             pass
     res = os.path.isfile(SANDBOX_BINARY) and access(SANDBOX_BINARY, os.X_OK)
+    if res:
+        try:
+            r, s = spawn_get_output([SANDBOX_BINARY, "--version"])
+            res = (r == 0) and ("gentoo" in s[0].lower())
+        except ExecutionFailure:
+            res = False
     is_sandbox_capable.cached_result = res
     return res
 


### PR DESCRIPTION
Check the output of '${SANDBOX_BINARY} --version' to determine whether
sandbox is actually the Gentoo sandbox tool. For example, on Fedora
the path is used by SELinux sandbox which serves a different purpose
and causes hard-to-debug failures in pkgcore.