### PR TITLE
portage_conf: Fix undefined var ref in profile error handling

### DIFF
--- a/pkgcore/ebuild/portage_conf.py
+++ b/pkgcore/ebuild/portage_conf.py
@@ -193,7 +193,7 @@ def add_profile(config, config_dir, profile_override=None):
     if paths is None:
         raise errors.ComplexInstantiationError(
             '%s expands to %s, but no profile detected' %
-            (pjoin(base_path, 'make.profile'), profile))
+            (pjoin(config_dir, 'make.profile'), profile))
 
     user_profile_path = pjoin(config_dir, 'profile')
     if os.path.isdir(user_profile_path):


### PR DESCRIPTION
Not sure if I'm using the most correct replacement, but it's the same as in `_find_profile_link()`.