### PR TITLE
Fix PATH quoting in bash/generate_global_func_list.bash

### DIFF
--- a/bash/generate_global_func_list.bash
+++ b/bash/generate_global_func_list.bash
@@ -10,7 +10,7 @@
 export PKGCORE_BIN_PATH=$(dirname "$0")
 
 if [[ -z ${PKGCORE_CLEAN_ENV} ]]; then
-	exec env -i PKGCORE_PYTHON_PATH=${PKGCORE_PYTHON_PATH} PATH=${PATH} PKGCORE_CLEAN_ENV=1 "$0" "$@"
+	exec env -i PKGCORE_PYTHON_PATH="${PKGCORE_PYTHON_PATH}" PATH="${PATH}" PKGCORE_CLEAN_ENV=1 "$0" "$@"
 fi
 
 export LC_ALL=C # avoid any potential issues of unicode sorting for whacked func names


### PR DESCRIPTION
Fix PATH quoting in bash script to prevent failure on systems using
spaces in paths (such as OSX).