### PR TITLE
Stop forcing hardcoded system directories to be prepended to PATH.

### DIFF
--- a/pkgcore/const.py
+++ b/pkgcore/const.py
@@ -28,8 +28,6 @@ BASH_BINARY        = find_binary('bash')
 COPY_BINARY        = find_binary('cp')
 
 HOST_NONROOT_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
-HOST_ROOT_PATHS    = ("/usr/local/sbin", "/usr/local/bin", "/usr/sbin",
-                      "/usr/bin", "/sbin", "/bin")
 
 # no longer used.
 LIBFAKEROOT_PATH   = "/usr/lib/libfakeroot.so"

--- a/pkgcore/ebuild/processor.py
+++ b/pkgcore/ebuild/processor.py
@@ -957,7 +957,6 @@ def expected_ebuild_env(pkg, d=None, env_source_override=None, depends=False):
 
     if not depends:
         path = list(const.PATH_FORCED_PREPEND)
-        path.extend(const.HOST_ROOT_PATHS)
         for eapi in xrange(pkg.eapi, -1, -1):
             eapi_helper_dir = pjoin(e_const.EBUILD_HELPERS_PATH, str(eapi))
             if os.path.exists(eapi_helper_dir):


### PR DESCRIPTION
This allows the user to have control over which programs get found in PATH by setting own search order, in addition to some flexibility on systems with a nonstandard directory structure.

const.HOST_ROOT_PATHS isn't used anywhere else, therefore it's removed.