### PR TITLE
metadata: Include _eclass_exported_funcs mapping

### DIFF
--- a/ebd/ebuild.lib
+++ b/ebd/ebuild.lib
@@ -518,12 +518,26 @@ __dump_metadata_keys() {
 	set +f
 
 	# defined phases... fun one.
-	local phases
+	local phases exp_funcs func tmp
 	for key in pkg_{pretend,configure,info,{pre,post}{rm,inst},setup} \
 		src_{unpack,prepare,configure,compile,test,install}; do
-			__is_function "${key}" && phases+=${phases:+ }${key}
+			if __is_function "${key}"; then
+				phases+=${phases:+ }${key}
+				if [[ $(declare -F "${key}") == *ebuild-default-functions.lib ]]; then
+					# eclass exported function
+					tmp=$(declare -f "${key}")
+					tmp=${tmp#*\{}
+					tmp=${tmp%_${key}*}
+					func=( ${tmp} )
+				else
+					# ebuild exported function
+					func=-
+				fi
+				exp_funcs+="${exp_funcs:+ }${key}:${func}"
+			fi
 	done
 	__ebd_write_line "key DEFINED_PHASES=${phases:--}"
+	__ebd_write_line "key _EXPORTED_FUNCS=${exp_funcs:--}"
 }
 
 set +f

--- a/pkgcore/ebuild/ebuild_src.py
+++ b/pkgcore/ebuild/ebuild_src.py
@@ -395,6 +395,8 @@ class package_factory(metadata.factory):
         if inherited:
             mydata["_eclasses_"] = self._ecache.get_eclass_data(
                 inherited.split())
+        # TODO: proper types
+        mydata["_eclass_exported_funcs"] = mydata["_EXPORTED_FUNCS"]
         mydata['_chf_'] = chksum.LazilyHashedPath(pkg.path)
 
         for x in wipes:


### PR DESCRIPTION
This is my early work on making an explicit record of which phase function is used from which eclass, mostly for QA purposes. Since this is hard to obtain without rerunning ebuild, I'm storing the values in cache. Cache format and methods require review and better suggestions are welcome.
