### PR TITLE
merge.triggers: Pass -X to ldconfig to avoid updating symlinks

### DIFF
--- a/pkgcore/merge/triggers.py
+++ b/pkgcore/merge/triggers.py
@@ -286,7 +286,8 @@ class mtime_watcher(object):
 
 
 def update_elf_hints(root):
-    return spawn.spawn(["/sbin/ldconfig", "-r", root], fd_pipes={1:1, 2:2})
+    return spawn.spawn(["/sbin/ldconfig", "-X", "-r", root],
+        fd_pipes={1:1, 2:2})
 
 
 class ldconfig(base):


### PR DESCRIPTION
Always use 'ldconfig -X' in order to prevent ldconfig from updating
SONAME symlinks. Those symlinks should already be correctly handled by
ebuilds, and letting ldconfig alter them may result in unintentional
'upgrade' of a symlink when newer library has not (yet) been cleaned up.