### PR TITLE
Fix rmdir() to cover potential errno.EEXIST on non-empty dirs

### DIFF
--- a/pkgcore/binpkg/repository.py
+++ b/pkgcore/binpkg/repository.py
@@ -350,7 +350,10 @@ class tree(prototype.tree):
         try:
             os.rmdir(pjoin(self.base, pkg.category))
         except OSError as oe:
-            if oe.errno != errno.ENOTEMPTY:
+            # POSIX specifies either ENOTEMPTY or EEXIST for non-empty dir
+            # in particular, Solaris uses EEXIST in that case
+            # https://github.com/pkgcore/pkgcore/pull/181
+            if oe.errno not in (errno.ENOTEMPTY, errno.EEXIST):
                 raise
             del oe
 

--- a/pkgcore/ebuild/ebd.py
+++ b/pkgcore/ebuild/ebd.py
@@ -333,7 +333,10 @@ class ebd(object):
             try:
                 os.rmdir(os.path.dirname(self.builddir))
             except EnvironmentError as e:
-                if e.errno != errno.ENOTEMPTY:
+                # POSIX specifies either ENOTEMPTY or EEXIST for non-empty dir
+                # in particular, Solaris uses EEXIST in that case
+                # https://github.com/pkgcore/pkgcore/pull/181
+                if e.errno not in (errno.ENOTEMPTY, errno.EEXIST):
                     raise
         except EnvironmentError as e:
             raise_from(format.GenericBuildError(
@@ -894,7 +897,10 @@ class ebuild_mixin(object):
             try:
                 os.rmdir(os.path.dirname(builddir))
             except EnvironmentError as e:
-                if e.errno != errno.ENOTEMPTY:
+                # POSIX specifies either ENOTEMPTY or EEXIST for non-empty dir
+                # in particular, Solaris uses EEXIST in that case
+                # https://github.com/pkgcore/pkgcore/pull/181
+                if e.errno not in (errno.ENOTEMPTY, errno.EEXIST):
                     raise
 
 

--- a/pkgcore/vdb/ondisk.py
+++ b/pkgcore/vdb/ondisk.py
@@ -187,7 +187,10 @@ class tree(prototype.tree):
             try:
                 os.rmdir(pjoin(self.location, pkg.category))
             except OSError as oe:
-                if oe.errno != errno.ENOTEMPTY:
+                # POSIX specifies either ENOTEMPTY or EEXIST for non-empty dir
+                # in particular, Solaris uses EEXIST in that case
+                # https://github.com/pkgcore/pkgcore/pull/181
+                if oe.errno not in (errno.ENOTEMPTY, errno.EEXIST):
                     raise
                 # silently swallow it;
                 del oe


### PR DESCRIPTION
Fix rmdir() uses to cover both the possibility of errno.ENOTEMPTY
and errno.EEXIST for non-empty directories. This behavior (either error)
is specified by POSIX, and Solaris returns EEXIST rather than ENOTEMPTY.