### PR TITLE
ebuild/profiles: support profile-formats = profile-set

### DIFF
--- a/pkgcore/ebuild/profiles.py
+++ b/pkgcore/ebuild/profiles.py
@@ -153,17 +153,23 @@ class ProfileNode(object):
 
     @load_property("packages")
     def packages(self, data):
+        repo_config = self.repoconfig
+        profile_set = repo_config is not None and 'profile-set' in repo_config.profile_formats
         # sys packages and visibility
         sys, neg_sys, vis, neg_vis = [], [], [], []
         for line in data:
             if line[0] == '-':
                 if line[1] == '*':
                     neg_sys.append(self.eapi_atom(line[2:]))
+                elif profile_set:
+                    neg_sys.append(self.eapi_atom(line[1:]))
                 else:
                     neg_vis.append(self.eapi_atom(line[1:], negate_vers=True))
             else:
                 if line[0] == '*':
                     sys.append(self.eapi_atom(line[1:]))
+                elif profile_set:
+                    sys.append(self.eapi_atom(line))
                 else:
                     vis.append(self.eapi_atom(line, negate_vers=True))
         return self._packages_kls(

--- a/pkgcore/ebuild/repo_objs.py
+++ b/pkgcore/ebuild/repo_objs.py
@@ -380,7 +380,7 @@ class RepoConfig(syncable.tree):
     layout_offset = "metadata/layout.conf"
 
     default_hashes = ('size', 'sha256', 'sha512', 'whirlpool')
-    supported_profile_formats = ('pms', 'portage-1', 'portage-2')
+    supported_profile_formats = ('pms', 'portage-1', 'portage-2', 'profile-set')
     supported_cache_formats = ('pms', 'md5-dict')
 
     klass.inject_immutable_instance(locals())

--- a/pkgcore/test/ebuild/test_profiles.py
+++ b/pkgcore/test/ebuild/test_profiles.py
@@ -702,6 +702,30 @@ class TestPortage2ProfileNode(TestPortage1ProfileNode):
             self.setup_repo()
 
 
+class TestProfileSetProfileNode(TestPmsProfileNode):
+
+    def setup_repo(self):
+        self.repo_name = str(binascii.b2a_hex(os.urandom(10)))
+        with open(pjoin(self.dir, "profiles", "repo_name"), "w") as f:
+            f.write(self.repo_name)
+        ensure_dirs(pjoin(self.dir, "metadata"))
+        metadata = "masters = ''\nprofile-formats = profile-set"
+        with open(pjoin(self.dir, "metadata", "layout.conf"), "w") as f:
+            f.write(metadata)
+
+    def setUp(self, default=True):
+        TempDirMixin.setUp(self)
+        if default:
+            self.profile = pjoin("profiles", "default")
+            self.mk_profile(self.profile)
+            self.setup_repo()
+
+    def test_packages(self):
+        self.write_file("packages", "dev-sys/atom\n-dev-sys/atom2\n")
+        p = self.klass(pjoin(self.dir, self.profile))
+        self.assertEqual(p.system, ((atom("dev-sys/atom2"),), (atom("dev-sys/atom"),)))
+
+
 class TestOnDiskProfile(profile_mixin, TestCase):
 
     # use a derivative, using the inst caching disabled ProfileNode kls


### PR DESCRIPTION
Add minimal syntax support for profile-formats = profile-set in profile
packages files. In the portage implementation, @profile packages do
not limit parallelization of builds in the way that @system packages do.

@chutz