### PR TITLE
Disable sandbox when pkgcore is run inside sandbox

### DIFF
--- a/ebd/ebuild-daemon.bash
+++ b/ebd/ebuild-daemon.bash
@@ -146,16 +146,24 @@ __ebd_exec_main() {
 		die "failed sourcing ${PKGCORE_EBD_PATH}/ebuild.lib"
 	fi
 
-	if [[ -n ${SANDBOX_LOG} ]]; then
-		__ebd_read_line com
-		if [[ ${com} != "sandbox_log?" ]]; then
+	__ebd_read_line com
+	case ${com} in
+		"sandbox_log?")
+			if [[ ! ${SANDBOX_LOG} ]]; then
+				echo "sandbox enabled but no SANDBOX_LOG?!"
+				exit 1
+			fi
+			__ebd_write_line "${SANDBOX_LOG}"
+			declare -rx SANDBOX_LOG=${SANDBOX_LOG}
+			addwrite "${SANDBOX_LOG}"
+			;;
+		no_sandbox)
+			;;
+		*)
 			echo "unknown com '${com}'"
 			exit 1
-		fi
-		__ebd_write_line "${SANDBOX_LOG}"
-		declare -rx SANDBOX_LOG=${SANDBOX_LOG}
-		addwrite "${SANDBOX_LOG}"
-	fi
+			;;
+	esac
 
 	re=$(readonly | cut -s -d '=' -f 1 | cut -s -d ' ' -f 3)
 	for x in ${re}; do

--- a/pkgcore/ebuild/processor.py
+++ b/pkgcore/ebuild/processor.py
@@ -352,6 +352,8 @@ class EbuildProcessor(object):
         if self.__sandbox:
             self.write("sandbox_log?")
             self.__sandbox_log = self.read().split()[0]
+        else:
+            self.write("no_sandbox")
         self.dont_export_vars = self.read().split()
         # locking isn't used much, but w/ threading this will matter
         self.unlock()

--- a/pkgcore/spawn.py
+++ b/pkgcore/spawn.py
@@ -393,7 +393,10 @@ def is_sandbox_capable(force=False):
             return is_sandbox_capable.cached_result
         except AttributeError:
             pass
-    if not (os.path.isfile(SANDBOX_BINARY) and access(SANDBOX_BINARY, os.X_OK)):
+    if 'SANDBOX_ACTIVE' in os.environ:
+        # we can not spawn a sandbox inside another one
+        res = False
+    elif not (os.path.isfile(SANDBOX_BINARY) and access(SANDBOX_BINARY, os.X_OK)):
         res = False
     else:
         try:


### PR DESCRIPTION
Sandbox prohibits starting another sandbox inside a running one, which
in turns causes pkgcore to error out hard. To avoid this, just disable
sandbox when another sandbox is detected. The rule for that is copied
from sandbox itself.