### PR TITLE
ebuild.conditionals: Do not collapse nested AndRestrictions

### DIFF
--- a/pkgcore/ebuild/conditionals.py
+++ b/pkgcore/ebuild/conditionals.py
@@ -118,9 +118,6 @@ class DepSet(boolean.AndRestriction):
                     elif raw_conditionals[-1] in operators:
                         if len(depsets[-1]) == 1:
                             depsets[-2].append(depsets[-1][0])
-                        elif raw_conditionals[-1] == '' and (len(raw_conditionals) == 1 or ('' == raw_conditionals[-2])):
-                            # if the frame is an and and the parent is an and, collapse it in.
-                            depsets[-2].extend(depsets[-1])
                         else:
                             depsets[-2].append(
                                 operators[raw_conditionals[-1]](*depsets[-1]))

--- a/pkgcore/test/ebuild/test_conditionals.py
+++ b/pkgcore/test/ebuild/test_conditionals.py
@@ -103,7 +103,7 @@ class native_DepSetParsingTest(base):
         got = list(self.flatten_restricts(func(self, s)))
         wanted = list(v)
         self.assertEqual(got, v, msg="given %r\nexpected %r but got %r" %
-            (s, got, wanted))
+            (s, wanted, got))
 
     def check_str(self, s, func=base.gen_depset):
         if isinstance(s, (list, tuple)):

--- a/pkgcore/test/ebuild/test_conditionals.py
+++ b/pkgcore/test/ebuild/test_conditionals.py
@@ -127,7 +127,7 @@ class native_DepSetParsingTest(base):
         "a b",
         ( "",   []),
 
-        ( "( a b )", ("a", "b")),
+        ( "( a b )", ("&&", "(", "a", "b", ")")),
 
         "|| ( a b )",
 
@@ -137,14 +137,11 @@ class native_DepSetParsingTest(base):
         ( " x? ( a  b )",
             (["x"], "(", "a", "b", ")")),
 
-        # at some point, this should collapse it
         ( "x? ( y? ( a ) )",
             (["x"], "(", ["x", "y"], "(", "a", ")", ")")),
 
-        # at some point, this should collapse it
         ("|| ( || ( a b ) )", ["||", "(", "a", "b", ")"]),
 
-        # at some point, this should collapse it
         "|| ( || ( a b ) c )",
 
         ( "x? ( a !y? ( || ( b c ) d ) e ) f1 f? ( g h ) i",

--- a/src/depset.c
+++ b/src/depset.c
@@ -154,9 +154,6 @@ internal_parse_depset(PyObject *dep_str, char **ptr, int *has_conditionals,
 				goto internal_parse_depset_error;
 			} else if(!PyTuple_CheckExact(tmp)) {
 				item = tmp;
-			} else if (parent_func && and_func == parent_func) {
-				item = tmp;
-				item_size = PyTuple_GET_SIZE(item);
 			} else {
 				item = PyObject_CallObject(and_func, tmp);
 				Py_DECREF(tmp);


### PR DESCRIPTION
Disable collapsing nested AndRestrictions and preserve the exact structure of the input. While technically the nested and collapsed variants are equivalent, collapsing them makes it impossible to detect them in pkgcheck and report as a meaningless construct.

*Note*: I'm not using pkgcore as my packages manager. I'm testing it on pkgcheck but I'd appreciate if someone could confirm it doesn't hit some unlikely corner case in the PM part.