### PR TITLE
portage_conf: Ignore backup files (*~) in Portage configs

### DIFF
--- a/pkgcore/ebuild/portage_conf.py
+++ b/pkgcore/ebuild/portage_conf.py
@@ -269,6 +269,8 @@ def load_make_conf(vars_dict, path, allow_sourcing=False, required=True,
         sourcing_command = 'source'
 
     for fp in sorted_scan(os.path.realpath(path), follow_symlinks=True, nonexistent=True):
+        if fp.endswith('~'):
+            continue
         try:
             new_vars = read_bash_dict(
                 fp, vars_dict=vars_dict, sourcing_command=sourcing_command)
@@ -303,6 +305,8 @@ def load_repos_conf(path):
     repos = {}
 
     for fp in sorted_scan(os.path.realpath(path), follow_symlinks=True, nonexistent=True):
+        if fp.endswith('~'):
+            continue
         try:
             with open(fp) as f:
                 config = ConfigParser()


### PR DESCRIPTION
Ignore backup files (that is, files ending with a tilde) while
processing Portage configuration directories. Some of the configuration
manipulation tools (flaggie, eselect-repository) rely on this behavior
to create backups, and pkgcore currently reads them as additional
(obsolete) configuration.