### PR TITLE
Make external commands fatal during metadata regen

### DIFF
--- a/ebd/ebuild-daemon.bash
+++ b/ebd/ebuild-daemon.bash
@@ -387,6 +387,10 @@ __ebd_process_metadata() {
 			export PATH=${PKGCORE_METADATA_PATH}
 		fi
 
+		command_not_found_handle() {
+			die "Command not found during metadata regen: ${*}"
+		}
+
 		PKGCORE_SANDBOX_PID=${PPID}
 		__execute_phases "${2:-depend}" && exit 0
 		__ebd_process_sandbox_results

--- a/ebd/ebuild-daemon.bash
+++ b/ebd/ebuild-daemon.bash
@@ -380,7 +380,7 @@ __ebd_process_metadata() {
 		fi
 
 		command_not_found_handle() {
-			die "Command not found during metadata regen: ${*}"
+			die "External commands disallowed during metadata regen: ${*}"
 		}
 
 		PKGCORE_SANDBOX_PID=${PPID}

--- a/ebd/ebuild-daemon.bash
+++ b/ebd/ebuild-daemon.bash
@@ -217,13 +217,6 @@ __ebd_exec_main() {
 	done
 	unset -v x
 
-	# depend's speed up.  turn on qa interceptors by default, instead of flipping them on for each depends;
-	# same for loading depends .lib
-	# important- this needs be loaded after the declare -fr so it doesn't get marked as readonly.
-	# call.
-	export PKGCORE_ENABLE_QA="yes"
-	__qa_interceptors_enable
-
 	source "${PKGCORE_EBD_PATH}"/eapi/depend.lib >&2 || die "failed sourcing eapi/depend.lib"
 	__ebd_main_loop
 	exit 0
@@ -255,7 +248,6 @@ __ebd_process_ebuild_phases() {
 	local is_depends=true
 	if [[ ${phases/depend} == ${phases} ]]; then
 		is_depends=false
-		__qa_interceptors_disable
 	fi
 	local cont=0
 

--- a/ebd/ebuild-default-functions.lib
+++ b/ebd/ebuild-default-functions.lib
@@ -241,48 +241,6 @@ EXPORT_FUNCTIONS() {
 	done
 }
 
-PKGCORE_QA_INTERCEPTORS=(
-	javac java-config python python-config perl grep egrep fgrep sed
-	gcc "g++" cc bash awk nawk pkg-config
-)
-__QA_INTERCEPTORS_ACTIVE=false
-
-__qa_interceptors_enable() {
-	# Turn off extended glob matching so that g++ doesn't get incorrectly matched.
-	shopt -u extglob
-
-	${__QA_INTERCEPTORS_ACTIVE} && return
-	# QA INTERCEPTORS
-	local BIN BODY BIN_PATH
-	for BIN in "${PKGCORE_QA_INTERCEPTORS[@]}"; do
-		BIN_PATH=$(type -pf ${BIN})
-		if [[ $? != 0 ]]; then
-			BODY="echo \"*** missing command: ${BIN}\" >&2; return 127"
-		else
-			BODY="${BIN_PATH} \"\$@\"; return \$?"
-		fi
-		eval "${BIN}() {
-			echo -n \"QA Notice: ${BIN} in global scope: \" >&2
-			if [[ \${ECLASS_DEPTH} -gt 0 ]]; then
-				echo \"eclass \${ECLASS}\" >&2
-			else
-				echo \"\${CATEGORY}/\${PF}\" >&2
-			fi
-			${BODY}
-		}" || echo "error creating QA interceptor ${BIN}" >&2
-	done
-	__QA_INTERCEPTORS_ACTIVE=true
-} &> /dev/null
-
-__qa_interceptors_disable() {
-	${__QA_INTERCEPTORS_ACTIVE} || return
-	local x
-	for x in "${PKGCORE_QA_INTERCEPTORS[@]}"; do
-		unset -f ${x}
-	done
-	__QA_INTERCEPTORS_ACTIVE=false
-} &> /dev/null
-
-PKGCORE_BLACKLIST_VARS+=( ECLASS_DEPTH __QA_INTERCEPTORS_ACTIVE )
+PKGCORE_BLACKLIST_VARS+=( ECLASS_DEPTH )
 
 :

--- a/ebd/ebuild-env-utils.lib
+++ b/ebd/ebuild-env-utils.lib
@@ -64,7 +64,6 @@ __environ_dump() {
 	fi
 
 	local func_filters=( "${PKGCORE_BLACKLIST_FUNCS[@]}" ${PKGCORE_EAPI_FUNCS} "${PKGCORE_PRELOADED_ECLASSES[@]}" )
-	${__QA_INTERCEPTORS_ACTIVE:-false} && func_filters+=( "${PKGCORE_QA_INTERCEPTORS[@]}" )
 
 	# Punt any regex chars...
 	__escape_regex_array ___func_filters

--- a/ebd/ebuild.lib
+++ b/ebd/ebuild.lib
@@ -454,16 +454,10 @@ __execute_phases() {
 				PKGCORE_SAVE_ENV=false
 
 				PKGCORE_DIE_OUTPUT_DETAILS=false
-				if [[ -z ${PKGCORE_ENABLE_QA} ]]; then
-					__qa_interceptors_enable
-				fi
 
 				EBUILD_PHASE="depend"
 				__load_ebuild "${EBUILD}"
 
-				if [[ -z ${PKGCORE_ENABLE_QA} ]]; then
-					__qa_interceptors_disable
-				fi
 				if [[ ${EBUILD_PHASE} == depend ]]; then
 					__dump_metadata_keys
 				else

--- a/ebd/exit-handling.lib
+++ b/ebd/exit-handling.lib
@@ -105,7 +105,7 @@ __dump_trace() {
 	local funcname= sourcefile= lineno=
 	for (( n; n > ${strip}; n-- )); do
 		funcname=${FUNCNAME[${n} - 1]}
-		sourcefile=$(basename ${BASH_SOURCE[${n}]})
+		sourcefile=${BASH_SOURCE[${n}]##*/}
 		lineno=${BASH_LINENO[${n} - 1]}
 		# Display function arguments
 		local args= newargs=

--- a/pkgcore/ebuild/processor.py
+++ b/pkgcore/ebuild/processor.py
@@ -727,7 +727,9 @@ class EbuildProcessor(object):
 
     def _run_depend_like_phase(self, command, package_inst, eclass_cache,
                                extra_commands={}):
-        self._ensure_metadata_paths(const.HOST_NONROOT_PATHS)
+        # ebuild is not allowed to run any external programs during
+        # depend phases; use /dev/null since "" == "."
+        self._ensure_metadata_paths(("/dev/null",))
 
         env = expected_ebuild_env(package_inst, depends=True)
         data = self._generate_env_str(env)


### PR DESCRIPTION
Per the PMS, calling external commands during metadata regen is forbidden. Use `command_not_found_handle()` combined with forcing invalid `PATH` to catch them and die on them. I've also removed QA interceptors since all the listed commands are caught implicitly now.

All the failures in Gentoo were fixed already, and other repositories are WIP. It's also running on CI for a few days now.