### PR TITLE
edb/eapi/common.bash: Add "test" to pre-phase check for WORKDIR fallback

### DIFF
--- a/ebd/eapi/common.bash
+++ b/ebd/eapi/common.bash
@@ -62,7 +62,7 @@ __phase_pre_phase() {
 	else
 		local phase
 		# eapi4 blatant idiocy...
-		for phase in unpack prepare configure compile install; do
+		for phase in unpack prepare configure compile test install; do
 			[[ ${phase} == ${EBUILD_PHASE} ]] && break
 			__is_function src_${phase} || continue
 			# to reach here means that (for example), we're doing src_install, and src_compile was defined


### PR DESCRIPTION
This was omitted from the original EAPI 4, but retroactively fixed
by the following PMS commit:
https://gitweb.gentoo.org/proj/pms.git/commit/?id=0038f90a942f0856ae2533b26f709002a3ec80ae
