### PR TITLE
repo_objs: Include type in Maintainer for metadata.xml

### DIFF
--- a/src/pkgcore/ebuild/repo_objs.py
+++ b/src/pkgcore/ebuild/repo_objs.py
@@ -53,16 +53,20 @@ class Maintainer(object):
     :ivar name: full name
     :type description: C{unicode} object or C{None}
     :ivar description: description of maintainership.
+    :type maint_type: C{unicode} object or C{None}
+    :ivar maint_type: maintainer type (person or project).
     """
 
-    __slots__ = ('email', 'description', 'name')
+    __slots__ = ('email', 'description', 'name', 'maint_type')
 
-    def __init__(self, email=None, name=None, description=None):
+    def __init__(self, email=None, name=None, description=None,
+                 maint_type=None):
         if email is None and name is None:
             raise ValueError('need at least one of name and email')
         self.email = email
         self.name = name
         self.description = description
+        self.maint_type = maint_type
 
     def __str__(self):
         if self.name is not None:
@@ -118,7 +122,8 @@ class MetadataXml(object):
                 elif e.tag == 'description' and e.get('lang', 'en') == 'en':
                     description = e.text
             maintainers.append(Maintainer(
-                name=name, email=email, description=description))
+                name=name, email=email, description=description,
+                maint_type=x.get('type')))
 
         self._maintainers = tuple(maintainers)
 

--- a/tests/module/ebuild/test_repo_objs.py
+++ b/tests/module/ebuild/test_repo_objs.py
@@ -16,7 +16,8 @@ from pkgcore.repository import errors as repo_errors
 class TestMetadataXml(object):
 
     @staticmethod
-    def get_metadata_xml(maintainers=(), comments=(), local_use={}, longdescription=None):
+    def get_metadata_xml(maintainers=(), comments=(), local_use={},
+                         longdescription=None, maint_type=None):
         cs = '\n'.join(comments)
         ms = us = ls = ""
         if maintainers:
@@ -29,7 +30,9 @@ class TestMetadataXml(object):
                     ms[-1] += f"\n<description>{x[2]}</description>"
                 if len(x) > 3:
                     raise ValueError('maintainer data has too many fields')
-            ms = '\n'.join(f'<maintainer>{x}</maintainer>' for x in ms)
+            maint_type = (f'type="{maint_type}"' if maint_type is not None
+                          else '')
+            ms = '\n'.join(f'<maintainer {maint_type}>{x}</maintainer>' for x in ms)
         if local_use:
             us = ['<use>']
             for flag, desc in local_use.items():
@@ -64,7 +67,8 @@ f"""<?xml version="1.0" encoding="UTF-8"?>
             tuple(map(str, mx.maintainers))
         assert "funkymonkey@gmail.com" == mx.maintainers[0].email
         assert "funky monkey \N{SNOWMAN}" == mx.maintainers[0].name
-        assert None == mx.maintainers[0].description
+        assert mx.maintainers[0].description is None
+        assert mx.maintainers[0].maint_type is None
 
     def test_maintainer_with_desc(self):
         mx = self.get_metadata_xml(
@@ -73,6 +77,17 @@ f"""<?xml version="1.0" encoding="UTF-8"?>
         assert "foo@bar.com" == mx.maintainers[0].email
         assert "foobar" == mx.maintainers[0].name
         assert "Foobar" == mx.maintainers[0].description
+        assert mx.maintainers[0].maint_type is None
+
+    def test_maintainer_with_type(self):
+        mx = self.get_metadata_xml(
+            maintainers=(("foo@bar.com", "foobar"),),
+            maint_type='person')
+        assert ("foobar <foo@bar.com>",) == tuple(map(str, mx.maintainers))
+        assert "foo@bar.com" == mx.maintainers[0].email
+        assert "foobar" == mx.maintainers[0].name
+        assert mx.maintainers[0].description is None
+        assert "person" == mx.maintainers[0].maint_type
 
     def test_local_use(self):
         # empty...


### PR DESCRIPTION
Introduce a 'maint_type' (since 'type' is a builtin) attribute
in Maintainer, and use to indicate maintainer type from metadata.xml.