### PR TITLE
Fix pmaint sync buffering and flushing.

### DIFF
--- a/tests/module/scripts/test_pmaint.py
+++ b/tests/module/scripts/test_pmaint.py
@@ -141,7 +141,7 @@ class TestSync(TestCase, ArgParseMixin):
         self.assertOut(
             [
                 "*** syncing myrepo",
-                "*** failed syncing myrepo",
+                "!!! failed syncing myrepo",
                 ],
             myrepo=failure_section)
         self.assertOutAndErr(
@@ -149,11 +149,12 @@ class TestSync(TestCase, ArgParseMixin):
                 "*** syncing goodrepo",
                 "*** synced goodrepo",
                 "*** syncing badrepo",
-                "*** failed syncing badrepo",
-                "*** synced goodrepo",
-                ], [
                 "!!! failed syncing badrepo",
-                ],
+                "",
+                "*** sync results:",
+                "*** synced: goodrepo",
+                "!!! failed: badrepo",
+                ], [],
             'goodrepo', 'badrepo',
             goodrepo=success_section, badrepo=failure_section)
 


### PR DESCRIPTION
The code was written assuming that the out/err is unbuffered-
which is not true.  That in turn leads to the underlying repo sync operations
(which are usually raw processes writing to the fd) having output intermixed.

Thus just force a flush before handing off to the repo operations, and sync upon
return from it.

Additionally, while I'm in here, cleanup the output a bit and drop the
fetish for forcing output to stderr.