### PR TITLE
Sync/sqfs cleanup

### DIFF
--- a/data/config/repos.conf
+++ b/data/config/repos.conf
@@ -4,6 +4,8 @@ main-repo = gentoo
 [gentoo]
 location = /var/db/repos/gentoo
 repo-type = sqfs-v1
+# distfiles.gentoo.org certs aren't actually valid, defeating the purpose of https; thus
+# forcing http.
 sync-uri = http://distfiles.gentoo.org/snapshots/squashfs/gentoo-current.lzo.sqfs
 sync-type = sqfs
 

--- a/src/pkgcore/sync/http.py
+++ b/src/pkgcore/sync/http.py
@@ -25,7 +25,7 @@ class http_syncer(base.Syncer):
     def _sync(self, verbosity, output_fd, force=False, **kwargs):
         dest = self._pre_download()
 
-        if self.uri.startswith('https://'):
+        if self.uri.lower().startswith('https://'):
             # default to using system ssl certs
             context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         else:


### PR DESCRIPTION
1) add comment explaining why http is used for sqfs syncer
2) Fix up the http syncer to handle 304 more properly, and also throw in some defensive code while I'm in here for type handling since the original code looks wrong.
3) also tweak the http syncer to not care about protocol upper/lower case.