### PR TITLE
Issue 273 - removed sanity_check from TheadPool

### DIFF
--- a/src/pkgcore/ebuild/misc.py
+++ b/src/pkgcore/ebuild/misc.py
@@ -575,8 +575,7 @@ def run_sanity_checks(pkgs, domain, threads=None):
             if pkg_ops.supports("sanity_check"):
                 yield pkg_ops
 
-    with ThreadPoolExecutor(max_workers=threads) as executor:
-        for pkg, failed in executor.map(sanity_check, _filter_pkgs(pkgs)):
-            if failed:
-                failures[pkg].extend(failed)
+    for pkg, failed in map(sanity_check, _filter_pkgs(pkgs)):
+        if failed:
+            failures[pkg].extend(failed)
     return failures


### PR DESCRIPTION
This fixes #273 for me.  I'm not sure exactly what was causing the problem, but certain sets would always fail while others wouldn't.  Running it non-threaded works consistently.     

