### PR TITLE
Prep work in restrictions and atom area

### DIFF
--- a/src/pkgcore/ebuild/atom.py
+++ b/src/pkgcore/ebuild/atom.py
@@ -16,7 +16,7 @@ from snakeoil.demandload import demand_compile_regexp
 from ..restrictions import boolean, packages, restriction, values
 from ..restrictions.packages import AndRestriction as PkgAndRestriction
 from ..restrictions.packages import Conditional
-from ..restrictions.values import ContainmentMatch2
+from ..restrictions.values import ContainmentMatch
 from . import cpv, errors, restricts
 
 # namespace compatibility...
@@ -649,7 +649,7 @@ class transitive_use_atom(atom):
 
     @staticmethod
     def _mk_conditional(flag, payload, negate=False):
-        return Conditional('use', ContainmentMatch2(flag, negate=negate), payload)
+        return Conditional('use', ContainmentMatch(flag, negate=negate), payload)
 
     def _recurse_transitive_use_conds(self, atom_str, forced_use, varied):
         if not varied:

--- a/src/pkgcore/ebuild/atom.py
+++ b/src/pkgcore/ebuild/atom.py
@@ -446,8 +446,10 @@ class atom(boolean.AndRestriction, metaclass=klass.generic_equality):
 
         return cmp(self.repo_id, other.repo_id)
 
+    no_usedeps = klass.alias_attr("get_atom_without_use_deps")
+
     @property
-    def no_usedeps(self):
+    def get_atom_without_use_deps(self):
         """Return atom object stripped of USE dependencies."""
         if not self.use:
             return self

--- a/src/pkgcore/ebuild/conditionals.py
+++ b/src/pkgcore/ebuild/conditionals.py
@@ -86,9 +86,9 @@ class DepSet(boolean.AndRestriction):
                         node_conds = True
                         c = raw_conditionals[-1]
                         if c[0] == "!":
-                            c = values.ContainmentMatch2(c[1:-1], negate=True)
+                            c = values.ContainmentMatch(c[1:-1], negate=True)
                         else:
-                            c = values.ContainmentMatch2(c[:-1])
+                            c = values.ContainmentMatch(c[:-1])
 
                         depsets[-2].append(
                             packages.Conditional("use", c, tuple(depsets[-1])))

--- a/src/pkgcore/ebuild/domain.py
+++ b/src/pkgcore/ebuild/domain.py
@@ -449,7 +449,7 @@ class domain(config_domain):
         """Generates a restrict that matches iff the keywords are allowed."""
         if not accept_keywords and not self.profile.keywords:
             return packages.PackageRestriction(
-                "keywords", values.ContainmentMatch2(frozenset(default_keys)))
+                "keywords", values.ContainmentMatch(frozenset(default_keys)))
 
         if self.unstable_arch not in default_keys:
             # stable; thus empty entries == ~arch

--- a/src/pkgcore/ebuild/ebuild_src.py
+++ b/src/pkgcore/ebuild/ebuild_src.py
@@ -305,8 +305,8 @@ class base(metadata.package):
     @staticmethod
     def _mk_required_use_node(data):
         if data[0] == '!':
-            return values.ContainmentMatch2(data[1:], negate=True)
-        return values.ContainmentMatch2(data)
+            return values.ContainmentMatch(data[1:], negate=True)
+        return values.ContainmentMatch(data)
 
     @DynamicGetattrSetter.register
     def required_use(self):
@@ -330,7 +330,7 @@ class base(metadata.package):
 
                 return conditionals.DepSet.parse(
                     data,
-                    values.ContainmentMatch2, operators=operators,
+                    values.ContainmentMatch, operators=operators,
                     element_func=self._mk_required_use_node, attr='REQUIRED_USE')
         return conditionals.DepSet()
 

--- a/src/pkgcore/ebuild/restricts.py
+++ b/src/pkgcore/ebuild/restricts.py
@@ -195,9 +195,9 @@ class StaticUseDep(packages.PackageRestriction):
     def __init__(self, false_use, true_use):
         v = []
         if false_use:
-            v.append(values.ContainmentMatch2(false_use, negate=True, match_all=True))
+            v.append(values.ContainmentMatch(false_use, negate=True, match_all=True))
         if true_use:
-            v.append(values.ContainmentMatch2(true_use, match_all=True))
+            v.append(values.ContainmentMatch(true_use, match_all=True))
 
         l = len(v)
         if l == 2:
@@ -210,7 +210,7 @@ class StaticUseDep(packages.PackageRestriction):
         super().__init__('use', v)
 
 
-class _UseDepDefaultContainment(values.ContainmentMatch2):
+class _UseDepDefaultContainment(values.ContainmentMatch):
 
     __slots__ = ('if_missing',)
 
@@ -223,7 +223,7 @@ class _UseDepDefaultContainment(values.ContainmentMatch2):
         iuse, use = val
         if reduced_vals.issubset(iuse):
             # use normal pathways.
-            return values.ContainmentMatch2.match(self, use)
+            return values.ContainmentMatch.match(self, use)
         if self.if_missing == self.negate:
             # ex: if is_missing = False, missing flags are assumed falsed.
             # if negate is False, then we're not trying to disable the flags, trying to enable.
@@ -234,7 +234,7 @@ class _UseDepDefaultContainment(values.ContainmentMatch2):
         # recall that negate is unfortunately a double negative in labeling...
         reduced_vals = reduced_vals.intersection(iuse)
         if reduced_vals:
-            return values.ContainmentMatch2.match(self, use, _values_override=reduced_vals)
+            return values.ContainmentMatch.match(self, use, _values_override=reduced_vals)
         # nothing to match means all are missing, but the default makes them considered a match.
         return True
 
@@ -243,12 +243,12 @@ class _UseDepDefaultContainment(values.ContainmentMatch2):
         # see comments in .match for clarification of logic.
         iuse, use = val
         if reduced_vals.issubset(iuse):
-            return values.ContainmentMatch2.force_False(self, pkg, 'use', use)
+            return values.ContainmentMatch.force_False(self, pkg, 'use', use)
         if self.if_missing == self.negate:
             return False
         reduced_vals = reduced_vals.intersection(iuse)
         if reduced_vals:
-            return values.ContainmentMatch2.force_False(self, pkg, 'use', use, reduced_vals)
+            return values.ContainmentMatch.force_False(self, pkg, 'use', use, reduced_vals)
         return True
 
     def force_True(self, pkg, attr, val):
@@ -256,12 +256,12 @@ class _UseDepDefaultContainment(values.ContainmentMatch2):
         # see comments in .match for clarification of logic.
         iuse, use = val
         if reduced_vals.issubset(iuse):
-            return values.ContainmentMatch2.force_True(self, pkg, 'use', use)
+            return values.ContainmentMatch.force_True(self, pkg, 'use', use)
         if self.if_missing == self.negate:
             return False
         reduced_vals = reduced_vals.intersection(iuse)
         if reduced_vals:
-            return values.ContainmentMatch2.force_True(self, pkg, 'use', use, reduced_vals)
+            return values.ContainmentMatch.force_True(self, pkg, 'use', use, reduced_vals)
         return True
 
 

--- a/src/pkgcore/pkgsets/glsa.py
+++ b/src/pkgcore/pkgsets/glsa.py
@@ -127,7 +127,7 @@ class GlsaDirSet(metaclass=generic_equality):
             vuln = vuln_list[0]
         if arch is not None:
             vuln = packages.AndRestriction(vuln, packages.PackageRestriction(
-                "keywords", values.ContainmentMatch2(arch, match_all=False)))
+                "keywords", values.ContainmentMatch(arch, match_all=False)))
         invuln = (pkg_node.findall("unaffected"))
         if not invuln:
             # wrap it.

--- a/src/pkgcore/repository/prototype.py
+++ b/src/pkgcore/repository/prototype.py
@@ -393,7 +393,7 @@ class tree:
                     return []
                 cats_iter = [c]
             else:
-                cat_restrict.add(values.ContainmentMatch2(frozenset(cat_exact)))
+                cat_restrict.add(values.ContainmentMatch(frozenset(cat_exact)))
                 cats_iter = sorter(self._cat_filter(cat_restrict))
         elif cat_restrict:
             cats_iter = self._cat_filter(
@@ -411,7 +411,7 @@ class tree:
                     (c, p)
                     for c in cats_iter for p in pkg_exact)
             else:
-                pkg_restrict.add(values.ContainmentMatch2(frozenset(pkg_exact)))
+                pkg_restrict.add(values.ContainmentMatch(frozenset(pkg_exact)))
 
         if pkg_restrict:
             return self._package_filter(

--- a/src/pkgcore/restrictions/util.py
+++ b/src/pkgcore/restrictions/util.py
@@ -27,11 +27,11 @@ def collect_package_restrictions(restrict, attrs=None, invert=False):
                 'restrict must be of a restriction.base, '
                 f'not {r.__class__.__class__}: {r!r}'
             )
+    i = iflatten_func(restrict, _is_package_instance)
     if attrs is None:
-        for r in iflatten_func(restrict, _is_package_instance):
-            yield r
-    else:
-        attrs = frozenset(attrs)
-        for r in iflatten_func(restrict, _is_package_instance):
-            if invert == attrs.isdisjoint(getattr(r, 'attrs', ())):
-                yield r
+        return i
+    attrs = frozenset(attrs)
+    return (
+        r for r in i
+        if invert == attrs.isdisjoint(getattr(r, 'attrs', ()))
+    )

--- a/src/pkgcore/restrictions/values.py
+++ b/src/pkgcore/restrictions/values.py
@@ -283,14 +283,11 @@ class EqualityMatch(base, metaclass=generic_equality):
         return f'EqualityMatch: ={self.data}'
 
 
-class ContainmentMatch2(base, metaclass=hashed_base):
+class ContainmentMatch(base, metaclass=hashed_base):
     """Used for an 'in' style operation.
 
     For example, 'x86' in ['x86', '~x86']. Note that negation of this *does*
     not result in a true NAND when all is on.
-
-    Note that ContainmentMatch will be removed in favor of this class. When
-    that occurs an alias will be left in place for compatibility.
     """
 
     __slots__ = ('_hash', 'vals', 'all', 'negate')
@@ -451,26 +448,10 @@ class ContainmentMatch2(base, metaclass=hashed_base):
         negate = '!' if self.negate else ''
         return f'{negate}{restricts_str}'
 
-
-class ContainmentMatch(ContainmentMatch2):
-    """Used for an 'in' style operation.
-
-    For example, 'x86' in ['x86', '~x86']. Note that negation of this *does*
-    not result in a true NAND when all is on.
-
-    Deprecated in favor of ContainmentMatch2.
-    """
-
-    __slots__ = ()
-    __inst_caching__ = True
-
-    def __init__(self, *args, **kwargs):
-        # note that we're discarding any specialized __getitem__ on vals here.
-        # this isn't optimal, and should be special cased for known
-        # types (lists/tuples fex)
-        vals = frozenset(args)
-        match_all = kwargs.pop("all", False)
-        ContainmentMatch2.__init__(self, vals, match_all=match_all, **kwargs)
+# ContainmentMatch2 was added in f1d3c6f to deprecate ContainmentMatch;
+# cleanup took a while (2021).  This ContainmentMatch2 can be removed
+# by 2023 at latest (pkgcheck is the only known dependency on this).
+ContainmentMatch2 = ContainmentMatch
 
 
 class FlatteningRestriction(base, metaclass=generic_equality):

--- a/src/pkgcore/util/parserestrict.py
+++ b/src/pkgcore/util/parserestrict.py
@@ -19,7 +19,7 @@ class ParseError(ValueError):
 
 
 def comma_separated_containment(attr, values_kls=frozenset, token_kls=str):
-    """Helper for parsing comma-separated strings to a ContainmentMatch2.
+    """Helper for parsing comma-separated strings to a ContainmentMatch.
 
     :param attr: name of the attribute.
     :return: a parse function: takes a string of comma-separated values,
@@ -28,7 +28,7 @@ def comma_separated_containment(attr, values_kls=frozenset, token_kls=str):
     """
     def _parse(value):
         return packages.PackageRestriction(
-            attr, values.ContainmentMatch2(
+            attr, values.ContainmentMatch(
                 values_kls(token_kls(piece.strip()) for piece in value.split(','))
             )
         )


### PR DESCRIPTION
To resolve the issues with combinatorial explosion of transitive use deps, the underlying restriction framework is going to have to be refactored.  Simply put the notion of 'force_True' equivalent operations on a repository were ideas that didn't pan out due to EAPI going in a way I didn't predict, and the CNF/DNF explosions that have followed are derived from that.

To fix that underlying problem, the notion of "mutable configurable packages" in a repository is going to have to be separate out- likely into another layer (domain, resolver plan, etc) that holds the changes in flight.

To get there- to evaluate if that is right- will require cleanup up restrictions and introducing more formalized visitation.  Currently we have the notion of visiting values and 'package'; 'package' is where the combinatorial explosion occurs for transitive use apps, and it's not going to possible to change that.  Fact is I'm not sure we should, anyways.

What's needed is to add another higher level of visitation that exposes CNF/DNF while exposing the configurable relationships to the visiter.  The point there is to make the visiter deal w/ a higher level API, but one that allows it to introspect/slice/dice/whatever on it's own, allowing it to operate more efficiently than a forced normalized form.

That's the end goal, and this PR is prep work- cleanup and removal of anything particularly ugly I left years ago.  The commits detail this in full, but relevant points:

1) src/atom.c should be dead at this point since it's py2k only.  Either way, it had dead load statements which I pruned since I noticed them while doing other cleanup.
2) values.ContainmentMatch2 is what everything uses, and was to replace values.ContainmentMatch a decade ago.  I forgot to do that cleanup/replacement.  At this point I've updated all of pkgcore code and just aliased the usages together since pkgcheck has some awareness. A proper warning of deprecation seems warranted, although I'm kind of fine w/ being lazy on that front.
3) MInor rename w/in atom to give a more clear property name for 'no_usedeps'; at first glance one can't tell if it's a boolean indicating "it has no usedeps", or if it's something that does a render.  I've left an alias in place for compatiability, and have renamed it to 'get_atom_without_use_deps' for clarity.