### PR TITLE
Update binpkg location to portage's new defaults.

### DIFF
--- a/data/config/repos.conf
+++ b/data/config/repos.conf
@@ -10,5 +10,5 @@ sync-uri = http://distfiles.gentoo.org/snapshots/squashfs/gentoo-current.lzo.sqf
 sync-type = sqfs
 
 [binpkgs]
-location = /var/db/repos/binpkgs
+location = /var/cache/binpkgs
 repo-type = binpkg-v1


### PR DESCRIPTION
Sometime on/before a859556ffaa4b3f551232 in portage repo, the
default was moved for where binpkg repo lives.  This updates
pkgcore's notion to align.