### PR TITLE
Less magic package _get_attr machinery

### DIFF
--- a/src/pkgcore/ebuild/cpv.py
+++ b/src/pkgcore/ebuild/cpv.py
@@ -242,7 +242,6 @@ class CPV(base.base):
     :ivar revision: str revision
     :ivar versioned_atom: atom matching this exact version
     :ivar unversioned_atom: atom matching all versions of this package
-    :cvar _get_attr: mapping of attr:callable to generate attributes on the fly
     """
 
     __slots__ = ("cpvstr", "key", "category", "package", "version", "revision", "fullver")

--- a/src/pkgcore/ebuild/ebuild_built.py
+++ b/src/pkgcore/ebuild/ebuild_built.py
@@ -12,6 +12,7 @@ from snakeoil.currying import post_curry
 from snakeoil.data_source import local_source
 from snakeoil.mappings import IndeterminantDict
 from snakeoil.obj import DelayedInstantiation
+from snakeoil.sequences import iter_stable_unique
 
 from pkgcore import fetch
 from pkgcore.ebuild import ebuild_src, conditionals, triggers
@@ -19,45 +20,15 @@ from pkgcore.ebuild.eapi import get_eapi
 from pkgcore.fs.livefs import scan
 from pkgcore.merge import engine
 from pkgcore.package import metadata
+from pkgcore.package.base import DynamicGetattrSetter
 
 # TODO: forcibly enable lazy imports to resolve circular module imports
 with demandimport.enabled():
     from pkgcore.ebuild import ebd
 
 
-def passthrough(inst, attr):
+def _passthrough(inst, attr):
     return inst.data[attr]
-
-def passthrough_repo(inst):
-    repo = inst.data.get('source_repository')
-    if repo is None:
-        repo = inst.data.get('repository')
-        # work around managers storing this in different places.
-        if repo is None:
-            # finally, do the strip ourselves since this can come
-            # back as '\n' from binpkg Packages caches...
-            repo = inst.data.get('REPO', '').strip()
-            if not repo:
-                repo = None
-    if repo:
-        return repo.strip()
-    return None
-
-
-def wrap_inst(self, wrap, inst):
-    return wrap(inst(self), self.use)
-
-
-def generate_eapi(self):
-    eapi_magic = self.data.pop("EAPI", "0")
-    if not eapi_magic:
-        # "" means EAPI 0
-        eapi_magic = '0'
-    eapi = get_eapi(str(eapi_magic).strip())
-    # This can return None... definitely the wrong thing right now
-    # for an unsupported eapi. Fix it later.
-    return eapi
-
 
 def _chost_fallback(initial, self):
     o = self.data.get(initial)
@@ -66,6 +37,9 @@ def _chost_fallback(initial, self):
         if o is None:
             return o
     return o.strip()
+
+def _render_and_evaluate_attr(self, attr_func, render_func):
+    return render_func(attr_func(self), self.use)
 
 
 class package(ebuild_src.base):
@@ -77,9 +51,25 @@ class package(ebuild_src.base):
     immutable = True
     allow_regen = False
 
-    @property
-    def tracked_attributes(self):
-        return tuple(super().tracked_attributes) + ("contents", "use", "environment")
+    __slots__ = ()
+
+    # Data in a 'built' ebuild may not be stored in finalized/rendered form, thus
+    # for all configurables, for it to be rendered if accessed.
+    # Note that since _get_attr doesn't  vary across EAPI, we can ignore tracked_attributes-
+    # we render either way (because the underlying API irregardless of EAPI must be usable, even
+    # if returned data is effectively empty).  Finally, note that this just maps the list across;
+    # it's expected that certain attributes that are known to have no meaning for a 'built' package
+    # are nulled (for example, fetchables: nothing to fetch).
+    locals().update({
+        attr_name: DynamicGetattrSetter.register(
+            post_curry(
+                _render_and_evaluate_attr,
+                ebuild_src.package._get_attr[attr_name],
+                render_func
+            )
+        )
+        for attr_name, render_func in ebuild_src.package._config_wrappables.items()
+    })
 
     @property
     def _operations(self):
@@ -88,36 +78,72 @@ class package(ebuild_src.base):
     # hack, not for consumer usage
     _is_from_source = False
 
-    _empty_fetchable = conditionals.DepSet.parse('', fetch.fetchable, operators={})
-
     built = True
 
-    _get_attr = dict(ebuild_src.package._get_attr)
-    _get_attr.update((x, partial(_chost_fallback, x.upper()))
-                     for x in ("cbuild", "chost", "ctarget"))
-    _get_attr.update((x, post_curry(passthrough, x))
-                     for x in ("contents", "environment"))
-    _get_attr.update((x, lambda s,x=x: s.data.get(x.upper(), ""))
-                     for x in ("cflags", "cxxflags", "ldflags"))
-    _get_attr.update((x, lambda s,x=x: tuple(s.data.get(x.upper(), "").split()))
-                     for x in ("distfiles", "iuse_effective", "inherited"))
-    _get_attr["source_repository"] = passthrough_repo
-    _get_attr["fetchables"] = lambda s: s._empty_fetchable
-    _get_attr["use"] = lambda s: DelayedInstantiation(
-        frozenset, lambda: frozenset(s.data["USE"].split()))
-    _get_attr["eapi"] = generate_eapi
+    cbuild = DynamicGetattrSetter.register(partial(_chost_fallback, 'CBUILD'))
+    chost = DynamicGetattrSetter.register(partial(_chost_fallback, 'CHOST'))
+    ctarget = DynamicGetattrSetter.register(partial(_chost_fallback, 'CTARGET'))
+    contents = DynamicGetattrSetter.register(post_curry(_passthrough, 'contents'))
+    environment = DynamicGetattrSetter.register(partial(_passthrough, 'environment'))
 
-    __slots__ = tuple(set(_get_attr.keys()) - set(ebuild_src.package._get_attr.keys()))
+    @property
+    def tracked_attributes(self):
+        # tracked attributes varies depending on EAPI, thus this hbas to be runtime computed.
+        return tuple(
+            iter_stable_unique(
+                super().tracked_attributes,
+                ('contents', 'use', 'environment')
+            )
+        )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._get_attr.update(
-            (k, post_curry(
-                wrap_inst,
-                ebuild_src.package._config_wrappables[k],
-                ebuild_src.package._get_attr[k]))
-            for k in ebuild_src.package._config_wrappables
-            if k in super(package, self).tracked_attributes)
+    @DynamicGetattrSetter.register
+    def distfiles(self):
+        return tuple(self.data.get("DISTFILES", "").split())
+
+    @DynamicGetattrSetter.register
+    def iuse_effective(self):
+        return tuple(self.data.get("IUSE_EFFECTIVE", "").split())
+
+    @DynamicGetattrSetter.register
+    def inherited(self):
+        return tuple(self.data.get("INHERITED", "").split())
+
+    @DynamicGetattrSetter.register
+    def source_repository(self):
+        repo = self.data.get('source_repository')
+        if repo is None:
+            repo = self.data.get('repository')
+            # work around managers storing this in different places.
+            if repo is None:
+                # finally, do the strip ourselves since this can come
+                # back as '\n' from binpkg Packages caches...
+                repo = self.data.get('REPO', '').strip()
+                if not repo:
+                    repo = None
+        if isinstance(repo, str):
+            repo = repo.strip()
+        return repo if repo else None
+
+    @DynamicGetattrSetter.register
+    def fetchables(self, ret=conditionals.DepSet.parse('', fetch.fetchable, operators={})):
+        return ret
+
+    @DynamicGetattrSetter.register
+    def use(self):
+        return DelayedInstantiation(
+            frozenset, lambda: frozenset(self.data["USE"].split())
+        )
+
+    @DynamicGetattrSetter.register
+    def eapi(self):
+        eapi_magic = self.data.pop("EAPI", "0")
+        if not eapi_magic:
+            # "" means EAPI 0
+            eapi_magic = '0'
+        eapi = get_eapi(str(eapi_magic).strip())
+        # This can return None... definitely the wrong thing right now
+        # for an unsupported eapi. Fix it later.
+        return eapi
 
     def _update_metadata(self, pkg):
         raise NotImplementedError()

--- a/src/pkgcore/ebuild/ebuild_src.py
+++ b/src/pkgcore/ebuild/ebuild_src.py
@@ -250,7 +250,7 @@ class base(metadata.package):
         x: klass.alias_method("evaluate_depset")
         for x in (
             "bdepend", "depend", "rdepend", "pdepend",
-            "fetchables", "license", "src_uri", "restrict", "required_use",
+            "fetchables", "license", "restrict", "required_use",
         )
     }
 


### PR DESCRIPTION
Back in the old days, how this was written was the only way to achieve certain performance requirements (back when rotational was the norm, and this seriously mattered).  Also, decorators weren't available at the time, so that was a bit of a different era..  Times changed, and the functional style in use here doesn't make contributions easy for others, let alone easy to read.

The basic `_get_attr` approach can't be ripped out in a single shot due to pkgcheck knowledge of it, and due to the metadata package's `release_cached_data` need to know all attributes that were rendered, and remove them.  Said another way, this still has problems.

What this PR implements instead is refactoring the code into a pattern where `snakeoil.klass.jit_attr` can eventually be dropped in and the internal bookkeeping of `_get_attr` removed.

The commit messages have further details for each, and are worth a read if anything is unclear.

One final point- there were a few attributes that weren't being rendered and stored to the package instance.  IE, space was allocated for it- things like `tracked_attributes`.  In those cases I've converted the code so that it's a property- rendered each access- since access is infrequent for common use cases, but the memory overhead does exist.  Minor, but no point in wasting in this case.