### PR TITLE
update EbuildProcessor.is_alive to use waitpid

### DIFF
--- a/src/pkgcore/ebuild/processor.py
+++ b/src/pkgcore/ebuild/processor.py
@@ -134,7 +134,7 @@ def release_ebuild_processor(ebp):
     assert ebp not in inactive_ebp_list
     # We can't reuse processors that use custom fd mappings or are locked on
     # release for one reason or another.
-    if ebp.locked or ebp._fd_pipes:
+    if ebp.is_locked or ebp._fd_pipes:
         ebp.shutdown_processor()
     else:
         inactive_ebp_list.append(ebp)
@@ -636,7 +636,7 @@ class EbuildProcessor:
         """Unlock the processor."""
         self.processing_lock = False
 
-    locked = klass.alias_attr('processing_lock')
+    is_locked = klass.alias_attr('processing_lock')
 
     @property
     def is_alive(self):


### PR DESCRIPTION
The original is_alive property was written to deal w/ very old python
versions that had issues with non-main threads doing signal handling,
thus this code.

That issue no longer exists, or I'm recalling the 'why' wrong and the code was just daft from day one.

Either way, just use an os.waitpid() instead. #177 is further context.

The surrounding PID handling still is attrocious and in needed of cleanup,
but that's a later date.

Note this splits the notion of 'is_alive' into "is_alive" (a process exists), and "is_responsive".  The code
actually cares a bit in this regard- it probably shouldn't- but it does.  Splitting the states to be clearer
should make it easier to rewrite the processor around async/coroutine notions at a later date, hence
why I'm making that change along w/ the waitpid related cleanup.
