### PR TITLE
[DO NOT MERGE, HELP NEEDED] pkg_uptodate experiment

### DIFF
--- a/ebd/ebuild.bash
+++ b/ebd/ebuild.bash
@@ -391,7 +391,7 @@ __execute_phases() {
 		PKGCORE_SUPPRESS_BASHRCS=false
 
 		case ${EBUILD_PHASE} in
-			nofetch|pretend)
+			nofetch|pretend|uptodate)
 				PKGCORE_SUPPRESS_BASHRCS=true
 				__init_environ
 

--- a/src/pkgcore/ebuild/ebuild_src.py
+++ b/src/pkgcore/ebuild/ebuild_src.py
@@ -343,7 +343,8 @@ class base(metadata.package):
     @property
     def mandatory_phases(self):
         return frozenset(
-            chain(self.defined_phases, self.eapi.default_phases))
+            chain(self.defined_phases, self.eapi.default_phases,
+                  ['uptodate']))
 
     @property
     def live(self):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import pkgcore.config
+import pkgcore.ebuild.atom
+import pkgcore.ebuild.ebd
+
+c = pkgcore.config.load_config(location='/etc/portage')
+d = c.get_default('domain')
+r = d.installed_repos[0]
+pkg = r.match(pkgcore.ebuild.atom.atom('app-misc/hello'))[0]
+
+op = pkgcore.ebuild.ebd.misc_operations(d, pkg)
+ret = op._generic_phase('uptodate', True, True)
+print(ret)
+
+import IPython
+IPython.embed()


### PR DESCRIPTION
@radhermit, this is what I've been able to hack so far. However, it fails with:

```pytb
Sandboxed process killed by signal: Broken pipe
Traceback (most recent call last):
  File "/home/mgorny/git/pkgcore/.venv/lib/python3.10/site-packages/pkgcore/ebuild/ebd.py", line 471, in run_generic_phase
    if not ebd.run_phase(phase, env, tmpdir=tmpdir, sandbox=sandbox,
  File "/home/mgorny/git/pkgcore/.venv/lib/python3.10/site-packages/pkgcore/ebuild/processor.py", line 428, in run_phase
    if not self.send_env(env, tmpdir=tmpdir):
  File "/home/mgorny/git/pkgcore/.venv/lib/python3.10/site-packages/pkgcore/ebuild/processor.py", line 725, in send_env
    fileutils.write_file(path, 'wb', data.encode())
  File "/home/mgorny/git/pkgcore/.venv/lib/python3.10/site-packages/snakeoil/fileutils.py", line 43, in write_file
    f = open(path, mode, encoding=encoding)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/portage/app-misc/hello-2.10-r1/temp/ebd-env-transfer'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/mgorny/git/pkgcore/test.py", line 13, in <module>
    ret = op._generic_phase('uptodate', True, True)
  File "/home/mgorny/git/pkgcore/.venv/lib/python3.10/site-packages/pkgcore/ebuild/ebd.py", line 323, in _generic_phase
    return run_generic_phase(
  File "/home/mgorny/git/pkgcore/.venv/lib/python3.10/site-packages/pkgcore/ebuild/ebd.py", line 497, in run_generic_phase
    raise format.GenericBuildError(
pkgcore.operations.format.GenericBuildError: failed build operation: Executing phase uptodate: Caught exception: [Errno 2] No such file or directory: '/tmp/portage/app-misc/hello-2.10-r1/temp/ebd-env-transfer'
```

The addition to hello ebuild is:
```bash
pkg_uptodate() {
	einfo "Yep, boss!"
	return 0
}
```