### PR TITLE
Start pkg_* phases in a dedicated empty directory

### DIFF
--- a/ebd/ebuild.bash
+++ b/ebd/ebuild.bash
@@ -348,6 +348,7 @@ __run_ebuild_phase() {
 	source "${PKGCORE_EBD_PATH}"/.generated/libs/${EAPI}/$1 \
 		|| die "failed sourcing EAPI ${EAPI} $1 phase scope lib"
 
+	cd "${PKGCORE_EMPTYDIR}" || die "unable to cd into ${PKGCORE_EMPTYDIR}"
 	__qa_run_function_if_exists __phase_pre_$1
 	__qa_run_function_if_exists pre_$1
 

--- a/src/pkgcore/ebuild/ebd.py
+++ b/src/pkgcore/ebuild/ebd.py
@@ -211,7 +211,8 @@ class ebd:
         for x, y in (("T", "temp"),
                      ("WORKDIR", "work"),
                      ("D", "image"),
-                     ("HOME", "homedir")):
+                     ("HOME", "homedir"),
+                     ("PKGCORE_EMPTYDIR", "empty")):
             self.env[x] = normpath(pjoin(self.builddir, y))
         self.env["D"] += self.eapi.options.trailing_slash
         self.env["PORTAGE_LOGFILE"] = normpath(pjoin(self.env["T"], "build.log"))
@@ -313,6 +314,10 @@ class ebd:
                 return True
             if 'selinux' not in self.features and 'suidctl' not in self.features:
                 return True
+
+        shutil.rmtree(self.env["PKGCORE_EMPTYDIR"], ignore_errors=True)
+        os.mkdir(self.env["PKGCORE_EMPTYDIR"])
+
         userpriv = self.userpriv and userpriv
         sandbox = self.sandbox and sandbox
         self._set_per_phase_env(phase, self.env)


### PR DESCRIPTION
Start pkg_* phases in a dedicated empty directory that's recreated
for every phase invoked.  This is required by EAPI 8 but since earlier
EAPIs allow any starting directory, it's fine to do it for all EAPIs.

Fixes #313