### PR TITLE
pkgcore.ebuild.cpv: fix isvalid_pkg_name() logic

### DIFF
--- a/src/pkgcore/ebuild/cpv.py
+++ b/src/pkgcore/ebuild/cpv.py
@@ -33,12 +33,17 @@ def isvalid_pkg_name(chunks):
     if not chunks[0] or chunks[0][0] == '+':
         # this means a leading -; additionally, '+asdf' is disallowed
         return False
-    mf = _pkg_re.match
-    if not all(mf(s) for s in chunks[:-1]):
+    # all remaining chunks can either be empty (meaning multiple
+    # hyphens) or must be valid chars
+    if not all(not s or _pkg_re.match(s) for s in chunks):
         return False
-    if chunks[-1]:
-        return mf(chunks[-1]) and not isvalid_version_re.match(chunks[-1])
+    # the package name must not end with a hyphen followed by anything that
+    # looks like a version -- need to ensure that we've gotten more than one
+    # chunk, i.e. at least one hyphen
+    if len(chunks) > 1 and isvalid_version_re.match(chunks[-1]):
+        return False
     return True
+
 
 def isvalid_rev(s):
     return s and s[0] == 'r' and s[1:].isdigit()

--- a/tests/ebuild/test_cpv.py
+++ b/tests/ebuild/test_cpv.py
@@ -24,15 +24,18 @@ class TestCPV:
 
     good_cats = (
         "dev-util", "dev+", "dev-util+", "DEV-UTIL", "aaa0",
-        "aaa-0", "multi/depth", "cross-dev_idiot.hacks-suck", "a")
+        "aaa-0", "multi/depth", "cross-dev_idiot.hacks-suck", "a",
+        "foo---", "multi--hyphen")
     bad_cats  = (".util", "_dev", "", "dev-util ", "multi//depth")
-    good_pkgs = ("diffball", "a9", "a9+", "a-100dpi", "diff-mode-")
-    bad_pkgs  = ("diffball ", "diffball-9", "a-3D", "ab--df", "-df", "+dfa")
+    good_pkgs = ("diffball", "a9", "a9+", "a-100dpi", "diff-mode-",
+                 "multi--hyphen", "timidity--", "frob---", "diffball-9-")
+    bad_pkgs  = ("diffball ", "diffball-9", "a-3D", "-df", "+dfa",
+                 "timidity--9f", "ormaybe---13_beta")
 
     good_cp   = (
         "bbb-9/foon", "dev-util/diffball", "dev-util/diffball-a9",
         "dev-ut-asdf/emacs-cvs", "xfce-base/xfce4", "bah/f-100dpi",
-        "dev-util/diffball-blah-monkeys")
+        "dev-util/diffball-blah-monkeys", "virtual/7z")
 
     good_vers = ("1", "2.3.4", "2.3.4a", "02.3", "2.03", "3d", "3D")
     bad_vers  = ("2.3a.4", "2.a.3", "2.3_", "2.3 ", "2.3.", "cvs.2")


### PR DESCRIPTION
Fix the package name verification logic not to incorrectly reject
packages that resemble a version number or that contain a series
of hyphens.  Document the algorithm better and add more tests for corner
cases.