### PR TITLE
ebuild.eclass: Support @PROVIDES in place of @INDIRECT_ECLASSES

### DIFF
--- a/src/pkgcore/ebuild/eclass.py
+++ b/src/pkgcore/ebuild/eclass.py
@@ -210,7 +210,7 @@ class EclassBlock(ParseEclassDoc):
             '@VCSURL:': ('vcsurl', False, self._tag_inline_arg, None),
             '@BLURB:': ('blurb', True, self._tag_inline_arg, None),
             '@DEPRECATED:': ('deprecated', False, self._tag_deprecated, False),
-            '@INDIRECT_ECLASSES:': ('indirect_eclasses', False, self._tag_inline_list, ()),
+            '@PROVIDES:': ('raw_provides', False, self._tag_inline_list, ()),
             '@MAINTAINER:': ('maintainers', True, self._tag_multiline_args, None),
             '@AUTHOR:': ('authors', False, self._tag_multiline_args, None),
             '@BUGREPORTS:': ('bugreports', False, self._tag_multiline_str, None),
@@ -617,3 +617,6 @@ class EclassDoc(AttrDict):
         """Convert eclassdoc object to an HTML 5 document."""
         from docutils.writers import html5_polyglot
         return self._to_docutils(html5_polyglot.Writer())
+
+    # backwards compatibility cruft, remove on next API breaker
+    indirect_eclasses = klass.alias_attr('raw_provides')

--- a/tests/ebuild/test_eclass.py
+++ b/tests/ebuild/test_eclass.py
@@ -15,7 +15,7 @@ FOO_ECLASS = '''
 # Report bugs somewhere.
 # @VCSURL: https://example.com/foo.eclass
 # @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
-# @INDIRECT_ECLASSES: bar
+# @PROVIDES: bar
 # @BLURB: Test eclass.
 # @DEPRECATED: bar or frobnicate
 # @DESCRIPTION:
@@ -91,7 +91,7 @@ class TestEclassDoc(TempDirMixin, TestCase):
         assert doc.vcsurl == 'https://example.com/foo.eclass'
         assert doc.blurb == 'Test eclass.'
         assert doc.deprecated == 'bar or frobnicate'
-        assert doc.indirect_eclasses == ('bar',)
+        assert doc.raw_provides == ('bar',)
         assert doc.maintainers == ('Random Person <maintainer@random.email>',)
         assert doc.authors == ('Another Person <another@random.email>',
                                'Random Person <maintainer@random.email>',)


### PR DESCRIPTION
Add support for @PROVIDES tag that replaces the pkgcore-specific
@INDIRECT_ECLASSES.  Add an alias attribute to preserve backwards
compatibility for the time being.

(pending https://archives.gentoo.org/gentoo-dev/message/bdc1a5c676cbd42c1362665f7d03e873)