### PR TITLE
cache: invalidate cache entries without INHERIT key

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,6 +3,13 @@ Release Notes
 =============
 
 ---------------------------
+pkgcore 0.12.6 (2021-??-??)
+---------------------------
+
+- pkgcore.cache: Invalidate cache entries if they are missing INHERIT
+  key, to avoid false positives from pkgcheck's InheritsCheck.
+
+---------------------------
 pkgcore 0.12.5 (2021-09-02)
 ---------------------------
 

--- a/src/pkgcore/cache/__init__.py
+++ b/src/pkgcore/cache/__init__.py
@@ -270,6 +270,10 @@ class base:
         eclass_data = cache_item.get('_eclasses_')
         if eclass_data is None:
             return True
+        # if the INHERIT key is missing yet we did inherit some eclasses,
+        # trigger a refresh to upgrade metadata cache
+        if cache_item.get('INHERIT') is None:
+            return False
         update = eclass_db.rebuild_cache_entry(eclass_data)
         if update is None:
             return False


### PR DESCRIPTION
Detect cache entries missing INHERIT key and force cache invalidation
for them.  This fixes false positives from pkgcheck's InheritsCheck
if the repository contains up-to-date metadata cache entries generated
by Portage or PkgCore prior to the introduction of INHERIT key.
If _eclasses_ are non-empty, then we can reasonably assume that INHERIT
must be non-empty as well (i.e. at least one eclass was inherited
directly).