### PR TITLE
ebuild.eclass_cache: Implement caching getter for EclassDocs

### DIFF
--- a/src/pkgcore/scripts/pmaint.py
+++ b/src/pkgcore/scripts/pmaint.py
@@ -428,7 +428,7 @@ def _eclass_main(options, out, err):
     for path in options.eclasses:
         try:
             with open(pjoin(options.output_dir, f'{os.path.basename(path)}.{ext}'), 'wt') as f:
-                obj = EclassDoc(path)
+                obj = EclassDoc(path, eclass_cache=options.repo.eclass_cache)
                 convert_func = getattr(obj, f'to_{options.format}')
                 f.write(convert_func())
         except ValueError as e:


### PR DESCRIPTION
(as part of the solution to problems in #323)

I've tried using WeakValueDictionary but it seems to have discarded the cache almost immediately which made it suck a lot.