### PR TITLE
ebuild.eclass: Add ABI_VERSION attribute to EclassDoc

### DIFF
--- a/src/pkgcore/ebuild/eclass.py
+++ b/src/pkgcore/ebuild/eclass.py
@@ -319,6 +319,8 @@ _eclass_blocks_re = re.compile(
 class EclassDoc(AttrDict):
     """Support parsing eclass docs for a given eclass path."""
 
+    ABI_VERSION = 5
+
     def __init__(self, path, /, *, sourced=False, repo=None):
         self.mtime = os.path.getmtime(path)
 


### PR DESCRIPTION
Add ABI_VERSION attribute that will be increased whenever EclassDoc's
internal ABI changes in incompatible ways.  This will be used to drive
pkgcheck's cache version, and therefore make it possible to make
incompatible changes inside pkgcore without having to keep manually
bumping the cache version in pkgcheck.