### PR TITLE
ebd_ipc: Fix unpack functionality broken via refactoring.

### DIFF
--- a/src/pkgcore/ebuild/ebd.py
+++ b/src/pkgcore/ebuild/ebd.py
@@ -679,7 +679,10 @@ class buildable(ebd, setup_mixin, format.build):
         # fetch distfiles
         if not self.verified_files:
             ops = self.domain.pkg_operations(self.pkg, observer=self.observer)
-            ops.fetch()
+            if ops.fetch():
+                # this break encapsulation and should be refactored.  Trace
+                # f35f2 and 6561eac for where this was refactored.
+                self.verified_files = ops.verified_files
 
         # symlink them into builddir
         if self.verified_files:


### PR DESCRIPTION
Rough tracing takes this back to logic being added to allow
for fetchers that have differing distdirs; the problem is
there is a break in the encapsulation.

Basically the fetcher has to return the location of the
content on disk, but just returns a boolean indicating success.

Being the invoking operation (setup usually) wasn't getting
updated for where the distfiles where (becaused the `verified_files`
attribute wasn't updated), unpack functionality was broken.

This represented via files being downloaded, but not being symlinked
into the spoof DISTDIR; thus no unpack.