### PR TITLE
Improver resolver UX for failures

### DIFF
--- a/src/pkgcore/scripts/pmerge.py
+++ b/src/pkgcore/scripts/pmerge.py
@@ -373,12 +373,11 @@ def display_failures(out, sequence, first_level=True, debug=False):
     frame = next(sequence)
     if first_level:
         # pops below need to exactly match.
-        out.first_prefix.extend((out.fg("red"), "!!!", out.reset))
-    out.first_prefix.append(" ")
+        out.first_prefix.extend((out.fg("red"), "!!! ", out.reset))
     out.write(f"request {frame.atom}, mode {frame.mode}")
     for pkg, steps in sequence:
         out.write(f"trying {pkg.cpvstr}")
-        out.first_prefix.append(" ")
+        out.first_prefix.append("  ")
         for step in steps:
             if isinstance(step, list):
                 display_failures(out, step, False, debug=debug)
@@ -401,7 +400,6 @@ def display_failures(out, sequence, first_level=True, debug=False):
             else:
                 out.write(step)
         out.first_prefix.pop()
-    out.first_prefix.pop()
     if first_level:
         for x in range(3):
             out.first_prefix.pop()


### PR DESCRIPTION
I'm basically convinced the resolver (and the underlying configurable abstraction/layer) needs a rewrite- it's been a problem since '08- but to get there, and to not annoy users, the UX needs to at least be more verbose in indicating what is and isn't a failure.  

Thus this PR: it adds color and fixes indentation.

Colors are:
* green == normal
* yellow == unsolved
* red == failure point.


Before:
![image](https://user-images.githubusercontent.com/1531180/134840018-b2b3871b-3346-4457-bff2-3d8afd5a4fa0.png)

After:
![image](https://user-images.githubusercontent.com/1531180/134840039-0ed173a4-8325-46da-8150-f3dc91561f69.png)

Folks may not consider this all that important, but if you're working on resolver code, having non-shit failure output is kind of a requirement.
