### PR TITLE
ebd: update EAPI 8 --disable-static rule per PMS update

### DIFF
--- a/ebd/eapi/8/src_configure.bash
+++ b/ebd/eapi/8/src_configure.bash
@@ -2,7 +2,7 @@ __econf_options_eapi8() {
 	if [[ $1 == *"--datarootdir"* ]]; then
 		echo "--datarootdir=${EPREFIX}/usr/share"
 	fi
-	if [[ $1 == *"--disable-static"* ]]; then
+	if [[ $1 == *"--disable-static"* || $1 == *"--enable-static"* ]]; then
 		echo "--disable-static"
 	fi
 }


### PR DESCRIPTION
Update the EAPI 8 --disable-static to be emitted when either
--disable-static or --enable-static occurs in configure --help output.
This is necessary to handle libtool packages correctly, and this is how
it was initially implemented in Portage.  PMS is being updated to match.

Bug: https://bugs.gentoo.org/814368