### PR TITLE
provide access to inherited package.deprecated and use_expand_desc

### DIFF
--- a/src/pkgcore/ebuild/repository.py
+++ b/src/pkgcore/ebuild/repository.py
@@ -556,7 +556,10 @@ class UnconfiguredTree(prototype.tree):
     @klass.jit_attr
     def deprecated(self):
         """Base deprecated packages restriction from profiles/package.deprecated."""
-        return packages.OrRestriction(*self.config.pkg_deprecated)
+        pkg_deprecated = set()
+        for repo in self.trees:
+            pkg_deprecated.update(repo.config.pkg_deprecated)
+        return packages.OrRestriction(*pkg_deprecated)
 
     def _regen_operation_helper(self, **kwds):
         return _RegenOpHelper(

--- a/src/pkgcore/ebuild/repository.py
+++ b/src/pkgcore/ebuild/repository.py
@@ -398,6 +398,14 @@ class UnconfiguredTree(prototype.tree):
         return ImmutableDict(mirrors)
 
     @klass.jit_attr
+    def use_expand_desc(self):
+        """Inherited USE_EXPAND settings for the repo."""
+        d = {}
+        for repo in self.trees:
+            d.update(repo.config.use_expand_desc)
+        return ImmutableDict(d)
+
+    @klass.jit_attr
     def use_expand_sort(self):
         """Inherited mapping of USE_EXPAND sorting keys for the repo."""
         d = {}

--- a/tests/ebuild/test_repository.py
+++ b/tests/ebuild/test_repository.py
@@ -299,6 +299,18 @@ class TestSlavedTree(TestUnconfiguredTree):
         repo = self.mk_tree(self.dir)
         self.assertEqual(sorted(repo.licenses), sorted(master_licenses + slave_licenses))
 
+    def test_package_deprecated(self):
+        with open(pjoin(self.master_pdir, 'package.deprecated'), 'w') as f:
+            f.write(textwrap.dedent('''\
+                # lalala
+                it-is/deprecated
+                <just/newer-than-42
+            '''))
+        repo = self.mk_tree(self.dir_slave)
+        self.assertEqual(sorted([atom('it-is/deprecated'),
+            atom('<just/newer-than-42')]),
+            sorted(list(repo.deprecated)))
+
     def test_masters(self):
         repo = self.mk_tree(self.dir)
         self.assertEqual(repo.masters, (self.master_repo,))

--- a/tests/ebuild/test_repository.py
+++ b/tests/ebuild/test_repository.py
@@ -311,6 +311,20 @@ class TestSlavedTree(TestUnconfiguredTree):
             atom('<just/newer-than-42')]),
             sorted(list(repo.deprecated)))
 
+    def test_use_expand_desc(self):
+        use_expand_desc = {
+            'example': (('example_foo', 'Build with foo'),
+                        ('example_bar', 'Build with bar'))
+        }
+        ensure_dirs(pjoin(self.master_pdir, 'desc'))
+        with open(pjoin(self.master_pdir, 'desc', 'example'), 'w') as f:
+            f.write(textwrap.dedent('''\
+                foo - Build with foo
+                bar - Build with bar
+            '''))
+        repo = self.mk_tree(self.dir)
+        assert use_expand_desc == dict(repo.use_expand_desc)
+
     def test_masters(self):
         repo = self.mk_tree(self.dir)
         self.assertEqual(repo.masters, (self.master_repo,))


### PR DESCRIPTION
Accumulate `deprecated` and `use_expand_desc` attributes not only from the repo but also from its masters.

(see conversation in pkgcore/pkgcheck#334)