### PR TITLE
processor: allow _ prefix for Bash variables

### DIFF
--- a/src/pkgcore/ebuild/processor.py
+++ b/src/pkgcore/ebuild/processor.py
@@ -691,7 +691,7 @@ class EbuildProcessor:
         for key, val in sorted(env_dict.items()):
             if key in self._readonly_vars:
                 continue
-            if not key[0].isalpha():
+            if not key[0].isalpha() and not key.startswith("_"):
                 raise KeyError(f"{key}: bash doesn't allow digits as the first char")
             if not isinstance(val, (str, list, tuple)):
                 raise ValueError(


### PR DESCRIPTION
With /etc/portage/env/foo containing e.g. "__PORTAGE_FOO=0", one would get:
```
Sandboxed process killed by signal: Broken pipe
!!! caught exception building sys-libs/glibc-2.34-r3: failed build operation:
Executing phase setup: Caught exception: "_PORTAGE_CONFCACHE: bash doesn't allow digits as the first char"
pmerge: error: failed build operation: Executing phase setup: Caught exception:
"_PORTAGE_CONFCACHE: bash doesn't allow digits as the first char"
```

It's fine for variables to begin with an underscore as well as A-z.

Signed-off-by: Sam James <sam@gentoo.org>