### PR TITLE
ebuild.ebuild_src: close resources when possible in eapi()

### DIFF
--- a/src/pkgcore/ebuild/ebuild_src.py
+++ b/src/pkgcore/ebuild/ebuild_src.py
@@ -252,6 +252,7 @@ class base(metadata.package):
             if (mo := _EAPI_str_regex.match(line)) and (eapi_str := mo.group('EAPI')):
                 eapi = _EAPI_regex.match(line).group('EAPI')
             break
+        i.close()
         try:
             return get_eapi(eapi)
         except ValueError as e:


### PR DESCRIPTION
With the following setup:

    $ export PYTHONWARNINGS=d,i::ImportWarning
    $ export PYTHONTRACEMALLOC=1
    $ pkgcheck scan ./app-editors/vim/vim-8.2.0814-r100.ebuild

produces a lot of warnings of this kind:

    /usr/lib/python3.9/site-packages/pkgcore/package/base.py:97: ResourceWarning: unclosed file <_io.TextIOWrapper name='./app-editors/vim/vim-9999.ebuild' mode='r' encoding='utf8'>
      val = functor(self)
    Object allocated at (most recent call last):
      File "/usr/lib/python3.9/site-packages/snakeoil/_fileutils.py", lineno 78
        handle = open(mypath, mode, encoding=encoding)

For the one ebuild above there are ~150 such warnings. The majority of
the calls appear to be the call to fileutils.readlines_utf8() that
produces a file handle that is not properly closed.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>