### PR TITLE
ebuild/repo_objs: close resources in _parse_xml()

### DIFF
--- a/src/pkgcore/ebuild/repo_objs.py
+++ b/src/pkgcore/ebuild/repo_objs.py
@@ -208,7 +208,8 @@ class LocalMetadataXml(MetadataXml):
 
     def _parse_xml(self):
         try:
-            MetadataXml._parse_xml(self, open(self._source, "rb", 32768))
+            with open(self._source, "rb", 32768) as src:
+                MetadataXml._parse_xml(self, src)
         except FileNotFoundError:
             self._maintainers = ()
             self._upstreams = ()


### PR DESCRIPTION
With the following setup:

    $ export PYTHONWARNINGS=d,i::ImportWarning
    $ export PYTHONTRACEMALLOC=1
    $ pkgcheck scan ./app-editors/vim/vim-8.2.0814-r100.ebuild

The following warning is produced (among others):

    /usr/lib/python3.9/site-packages/pkgcore/ebuild/repo_objs.py:211: ResourceWarning: unclosed file <_io.BufferedReader name='./app-editors/vim/metadata.xml'>
      MetadataXml._parse_xml(self, open(self._source, "rb", 32768))
    Object allocated at (most recent call last):
      File "/usr/lib/python3.9/site-packages/pkgcore/ebuild/repo_objs.py", lineno 211
        MetadataXml._parse_xml(self, open(self._source, "rb", 32768))

The Metadata._parse_xml() function does not attempt to close the
resource passed in. Fix by putting the function in a with-statement.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>