### PR TITLE
ebuild.repository: fix inheriting license groups

### DIFF
--- a/src/pkgcore/ebuild/domain.py
+++ b/src/pkgcore/ebuild/domain.py
@@ -48,7 +48,7 @@ from .misc import (ChunkedDataDict, chunked_data, collapsed_restrict_to_data, in
                    incremental_expansion_license, non_incremental_collapsed_restrict_to_data,
                    optimize_incrementals)
 from .portage_conf import PortageConfig
-from .repo_objs import OverlayedLicenses, RepoConfig
+from .repo_objs import Licenses, RepoConfig
 from .triggers import GenerateTriggers
 
 
@@ -421,7 +421,7 @@ class domain(config_domain):
 
     @klass.jit_attr_none
     def _default_licenses_manager(self):
-        return OverlayedLicenses(*self.source_repos_raw)
+        return Licenses(*self.source_repos_raw)
 
     def _apply_license_filter(self, master_licenses, pkg, mode):
         """Determine if a package's license is allowed."""

--- a/src/pkgcore/ebuild/repository.py
+++ b/src/pkgcore/ebuild/repository.py
@@ -279,10 +279,9 @@ class UnconfiguredTree(prototype.tree):
 
         self.masters = tuple(masters)
         self.trees = self.masters + (self,)
-        self.licenses = repo_objs.Licenses(self.location)
+        self.licenses = repo_objs.Licenses(self, *self.masters)
         self.profiles = self.config.profiles
         if masters:
-            self.licenses = repo_objs.OverlayedLicenses(*self.trees)
             self.profiles = repo_objs.OverlayedProfiles(*self.trees)
 
         # use mirrors from masters if not defined in the repo


### PR DESCRIPTION
A repo can define a group of licenses which inherits groups from
masters repos. In previous implementation, this was forbidden and
was printing weird output error.

The new implementation makes Licenses object directly support
master repos inheritance. No one had used the Licenses class, but
the OverlayedLicenses class, which the new implementation mimics
directly in one merged class, with correct ordering of evaluation.

Resolves: https://github.com/pkgcore/pkgcore/issues/335
Signed-off-by: Arthur Zamarin <arthurzam@gentoo.org>

---

TODO:

- [x] Improve coverage situation at least in this code