### PR TITLE
Sync metadata.xsd from proj/xml-schema repository (round 2)

### DIFF
--- a/data/xml-schema/metadata.xsd
+++ b/data/xml-schema/metadata.xsd
@@ -289,7 +289,6 @@
 			<xs:enumeration value='pypi'/>
 			<xs:enumeration value='rubygems'/>
 			<xs:enumeration value='sourceforge'/>
-			<xs:enumeration value='sourceforge-jp'/>
 			<xs:enumeration value='vim'/>
 		</xs:restriction>
 	</xs:simpleType>

--- a/data/xml-schema/metadata.xsd
+++ b/data/xml-schema/metadata.xsd
@@ -279,7 +279,6 @@
 			<xs:enumeration value='gentoo'/>
 			<xs:enumeration value='github'/>
 			<xs:enumeration value='gitlab'/>
-			<xs:enumeration value='gitorious'/>
 			<xs:enumeration value='google-code'/>
 			<xs:enumeration value='heptapod'/>
 			<xs:enumeration value='launchpad'/>


### PR DESCRIPTION
This removes sourceforge-jp which could not be done in the previous round (gentoo repo needed to be fixed first).
