### PR TITLE
ebuild/atom.py: atom.no_usedeps should include subslot

### DIFF
--- a/src/pkgcore/ebuild/atom.py
+++ b/src/pkgcore/ebuild/atom.py
@@ -463,6 +463,8 @@ class atom(boolean.AndRestriction, metaclass=klass.generic_equality):
                 s = '!' + s
         if self.slot:
             s += f':{self.slot}'
+        if self.subslot:
+            s += f'/{self.subslot}'
         return atom(s)
 
     def intersects(self, other):

--- a/tests/ebuild/test_atom.py
+++ b/tests/ebuild/test_atom.py
@@ -548,3 +548,23 @@ class Test_atom(test.TestRestriction):
         self.assertFalse(self.kls("=dev-util/diffball-1").is_simple)
         self.assertFalse(self.kls("dev-util/diffball[x]").is_simple)
         self.assertFalse(self.kls("dev-util/diffball[x?]").is_simple)
+
+    def test_get_atom_without_use_deps(self):
+        for original, wanted in (
+            ("<dev-util/diffball-2", "<dev-util/diffball-2"),
+            ("<dev-util/diffball-2[debug=,test=]", "<dev-util/diffball-2"),
+            ("=dev-util/diffball-2", "=dev-util/diffball-2"),
+            ("=dev-util/diffball-2[debug=,test=]", "=dev-util/diffball-2"),
+            ("=dev-util/diffball-2*", "=dev-util/diffball-2*"),
+            ("=dev-util/diffball-2*[debug=,test=]", "=dev-util/diffball-2*"),
+            ("dev-util/diffball:0", "dev-util/diffball:0"),
+            ("dev-util/diffball:0[debug=,test=]", "dev-util/diffball:0"),
+            ("dev-util/diffball:0/1.12", "dev-util/diffball:0/1.12"),
+            ("dev-util/diffball:0/1.12[debug=,test=]", "dev-util/diffball:0/1.12"),
+            ("!dev-util/diffball", "!dev-util/diffball"),
+            ("!dev-util/diffball[debug=,test=]", "!dev-util/diffball"),
+            ("!!dev-util/diffball", "!!dev-util/diffball"),
+            ("!!dev-util/diffball[debug=,test=]", "!!dev-util/diffball"),
+        ):
+            orig_atom = self.kls(original)
+            assert str(orig_atom.get_atom_without_use_deps) == wanted


### PR DESCRIPTION
We don't have a lot of users of the property no_usedeps for atom, so it was missed that we were ignoring the subslot value in the return. By including it, we are fixing an issue that was found with `VirtualKeywordsUpdate` in `virtual/podofo-build`.

Tested over at `::gentoo` repo, and it indeed fixed it for `virtual/podofo-build`.

Resolves: https://github.com/pkgcore/pkgcheck/issues/411