### PR TITLE
ebd: helpers: allow zstd for prepalldocs/prepinfo/prepman

### DIFF
--- a/ebd/helpers/common/prepalldocs
+++ b/ebd/helpers/common/prepalldocs
@@ -1,6 +1,6 @@
 #!/usr/bin/env pkgcore-ebuild-helper
 
-shopt -s extdebug
+shopt -s extdebug extglob
 
 if ! ${PKGCORE_PREFIX_SUPPORT:=false}; then
 	ED=${D}
@@ -30,6 +30,7 @@ if [[ -z ${PORTAGE_COMPRESS_SUFFIX} ]]; then
 		gzip)  suffix="gz";;
 		bzip2) suffix="bz2";;
 		xz)    suffix="xz";;
+		(p?)zstd suffix="zst";;
 		*)     die "prepalldocs error: please set PORTAGE_COMPRESS_SUFFIX in make.conf";;
 	esac
 fi

--- a/ebd/helpers/common/prepinfo
+++ b/ebd/helpers/common/prepinfo
@@ -1,6 +1,6 @@
 #!/usr/bin/env pkgcore-ebuild-helper
 
-shopt -s extdebug
+shopt -s extdebug extglob
 
 if ! ${PKGCORE_PREFIX_SUPPORT:=false}; then
 	ED=${D}
@@ -27,6 +27,7 @@ if [[ -z ${PORTAGE_COMPRESS_SUFFIX} ]]; then
 		gzip)  suffix="gz";;
 		bzip2) suffix="bz2";;
 		xz)    suffix="xz";;
+		(p?)zstd suffix="zst";;
 		*)     die "prepinfo: error fixing links: please set PORTAGE_COMPRESS_SUFFIX in make.conf";;
 	esac
 fi

--- a/ebd/helpers/common/prepman
+++ b/ebd/helpers/common/prepman
@@ -1,6 +1,6 @@
 #!/usr/bin/env pkgcore-ebuild-helper
 
-shopt -s extdebug
+shopt -s extdebug extglob
 
 if ! ${PKGCORE_PREFIX_SUPPORT:=false}; then
 	ED=${D}
@@ -21,6 +21,7 @@ if [[ -z ${PORTAGE_COMPRESS_SUFFIX} ]]; then
 		gzip)  suffix="gz";;
 		bzip2) suffix="bz2";;
 		xz)    suffix="xz";;
+		(p?)zstd suffix="zst";;
 		*)     die "prepman error: please set PORTAGE_COMPRESS_SUFFIX in make.conf";;
 	esac
 fi


### PR DESCRIPTION
Avoids the following error with PORTAGE_COMPRESS="pzstd" in make.conf
with e.g. `pemerge -v1 sys-apps/sed`:
```
 * ERROR: sys-apps/sed-4.8::gentoo failed:
 *   prepman error: please set PORTAGE_COMPRESS_SUFFIX in make.conf
 *
 * Working directory: '/var/tmp/portage/sys-apps/sed-4.8/work/sed-4.8'
```

Signed-off-by: Sam James <sam@gentoo.org>