### PR TITLE
portage_conf: fix timeout settings for rsync

### DIFF
--- a/src/pkgcore/ebuild/portage_conf.py
+++ b/src/pkgcore/ebuild/portage_conf.py
@@ -522,7 +522,7 @@ class PortageConfig(DictMixin):
 
         timeout = options.pop('PORTAGE_RSYNC_INITIAL_TIMEOUT', None)
         if timeout is not None:
-            base['connection_timeout'] = timeout
+            base['conn_timeout'] = timeout
 
         retries = options.pop('PORTAGE_RSYNC_RETRIES', None)
         if retries is not None:

--- a/src/pkgcore/sync/rsync.py
+++ b/src/pkgcore/sync/rsync.py
@@ -69,7 +69,7 @@ class rsync_syncer(base.ExternalSyncer):
         self.opts.extend(extra_opts)
         if compress:
             self.opts.append("--compress")
-        self.opts.append("--contimeout=%i" % int(conn_timeout))
+        self.opts.append(f"--contimeout={int(conn_timeout)}")
         self.excludes = list(self.default_excludes) + list(excludes)
         self.includes = list(self.default_includes) + list(includes)
         self.retries = int(retries)


### PR DESCRIPTION
When using rsync as sync type for a repository, if in `make.conf` `PORTAGE_RSYNC_INITIAL_TIMEOUT` was defined, it had crashed the code, as it was saving it into the wrong field name.

Bug: https://bugs.gentoo.org/872116