### PR TITLE
profiles: support package.bashrc files

### DIFF
--- a/src/pkgcore/ebuild/domain.py
+++ b/src/pkgcore/ebuild/domain.py
@@ -596,10 +596,11 @@ class domain(config_domain):
         return self
 
     def get_package_bashrcs(self, pkg):
-        for source in self.profile.bashrcs:
-            yield source
-        for source in self.bashrcs:
-            yield source
+        yield from self.profile.bashrcs
+        for restrict, bashrcs in self.profile.pkg_bashrcs:
+            if restrict.match(pkg):
+                yield from bashrcs
+        yield from self.bashrcs
         if not os.path.exists(self.ebuild_hook_dir):
             return
         # matching portage behavior... it's whacked.

--- a/src/pkgcore/ebuild/inspect_profile.py
+++ b/src/pkgcore/ebuild/inspect_profile.py
@@ -187,6 +187,15 @@ class bashrcs(_base, metaclass=_register_command):
             out.write(bashrc.path)
 
 
+class package_bashrc(_base, metaclass=_register_command):
+    """inspect package.bashrc"""
+
+    def __call__(self, namespace, out, err):
+        for package, bashrcs in namespace.profile.pkg_bashrcs:
+            bashrcs = ", ".join(s.path for s in bashrcs)
+            out.write(f'{package}: {bashrcs}')
+
+
 class keywords(_base, metaclass=_register_command):
     """inspect package.keywords"""
 

--- a/src/pkgcore/ebuild/repo_objs.py
+++ b/src/pkgcore/ebuild/repo_objs.py
@@ -682,7 +682,7 @@ class RepoConfig(syncable.tree, klass.ImmutableInstance, metaclass=WeakInstMeta)
 
     default_hashes = ('size', 'blake2b', 'sha512')
     default_required_hashes = ('size', 'blake2b')
-    supported_profile_formats = ('pms', 'portage-1', 'portage-2', 'profile-set')
+    supported_profile_formats = ('pms', 'portage-1', 'portage-2', 'profile-bashrcs', 'profile-set')
     supported_cache_formats = ('md5-dict', 'pms')
 
     __inst_caching__ = True


### PR DESCRIPTION
Add support for `profile-bashrcs` profile format, which adds support for per-profile bashrc mechanism `package.bashrc`, which enables to specify per restriction the extra bashrc files to run.

See portage(5) for format details.