### PR TITLE
plugin: also consider plugincache file's mtime

### DIFF
--- a/src/pkgcore/plugin.py
+++ b/src/pkgcore/plugin.py
@@ -101,9 +101,10 @@ def _read_cache_file(package, cache_path):
     if not cache_data:
         return {}
     try:
+        file_mtime = os.path.getmtime(cache_path) + 1  # 1 second of grace time
         for line in cache_data:
             module, mtime, entries = line.split(':', 2)
-            mtime = int(mtime)
+            mtime = max(file_mtime, int(mtime))
             # Needed because ''.split(':') == [''], not []
             if not entries:
                 entries = set()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -110,7 +110,7 @@ pkgcore_plugins = {'plugtest': [HiddenPlug]}
         plugin._global_cache.clear()
         method()
         method()
-        assert mtime == \
+        assert mtime <= \
             os.path.getmtime(pjoin(self.packdir, plugin.CACHE_FILENAME))
         # We cannot write this since it contains an unimportable plugin.
         assert not os.path.exists(pjoin(self.packdir2, plugin.CACHE_FILENAME))
@@ -175,7 +175,7 @@ pkgcore_plugins = {'plugtest': [HiddenPlug]}
             pjoin(self.packdir, plugin.CACHE_FILENAME))
         plugin._global_cache.clear()
         self._test_plug()
-        assert good_mtime == os.path.getmtime(pjoin(self.packdir, plugin.CACHE_FILENAME))
+        assert good_mtime <= os.path.getmtime(pjoin(self.packdir, plugin.CACHE_FILENAME))
         assert good_mtime != corrupt_mtime
 
     def test_rewrite_on_remove(self):


### PR DESCRIPTION
Also use plugincache file's mtime to determine if the plugin cache need update. Add a grace period of 1 second for the mtime check to avoid cases of unfortunate mtime changes in the file system unpack time.

Resolves: https://github.com/pkgcore/pkgcore/issues/376