### PR TITLE
Make EAPI 8 `--disable-static` logic libtool-specific

### DIFF
--- a/data/lib/pkgcore/ebd/eapi/8/src_configure.bash
+++ b/data/lib/pkgcore/ebd/eapi/8/src_configure.bash
@@ -2,7 +2,7 @@ __econf_options_eapi8() {
 	if [[ $1 == *"--datarootdir"* ]]; then
 		echo "--datarootdir=${EPREFIX}/usr/share"
 	fi
-	if [[ $1 == *"--disable-static"* || $1 == *"--enable-static"* ]]; then
+	if [[ $1 == *--enable-shared[^A-Za-z0-9+_.-]* && $1 == *--enable-static[^A-Za-z0-9+_.-]* ]]; then
 		echo "--disable-static"
 	fi
 }


### PR DESCRIPTION
* The intention has always been to only target `configure` scripts that use libtool, not just any script with a `--disable-static*` option.

* libtool has been using the same `configure` format for at least the past 15 years (going back to libtool 1.5.22):

  1. shared and static libraries enabled (the main use case): --enable-shared[=PKGS]  build shared libraries [default=yes] --enable-static[=PKGS]  build static libraries [default=yes]

  2. shared libraries enabled and static libraries disabled: --enable-static[=PKGS]  build static libraries [default=no] --enable-shared[=PKGS]  build shared libraries [default=yes]

  3. shared libraries disabled and static libraries enabled: --enable-shared[=PKGS]  build shared libraries [default=no] --enable-static[=PKGS]  build static libraries [default=yes]

Bug: https://bugs.gentoo.org/814380