### PR TITLE
Cleanup as of 2022-12-25

### DIFF
--- a/src/pkgcore/config/domain.py
+++ b/src/pkgcore/config/domain.py
@@ -40,13 +40,18 @@ class domain:
     def triggers(self):
         return tuple(self._triggers)
 
-    def pkg_operations(self, pkg, observer=None):
+    def get_pkg_operations(self, pkg, observer=None):
+        """Get the manager of package operations for the given package
+
+        If you wish to modify a package- invoke setup, install, etc- this is what's responsible
+        for giving you a common interface despite the format implementation varying.
+        """
         domain = self.get_package_domain(pkg)
         return pkg.operations(domain, observer=observer)
 
     def build_pkg(self, pkg, observer=None, failed=False, clean=True, **kwargs):
         domain = self.get_package_domain(pkg)
-        return domain.pkg_operations(pkg, observer=observer).build(
+        return domain.get_pkg_operations(pkg, observer=observer).build(
             observer=observer, failed=failed, clean=clean, **kwargs
         )
 

--- a/src/pkgcore/ebuild/atom.py
+++ b/src/pkgcore/ebuild/atom.py
@@ -132,7 +132,13 @@ class atom(boolean.AndRestriction, metaclass=klass.generic_equality):
                     elif x[0] == "-":
                         x = x[1:]
 
-                    if x[-1] == ")" and eapi not in ("0", "1", "2", "3"):
+                    if x[-1] == ")":
+                        if not eapi_obj.options.has_use_dep_defaults:
+                            raise errors.MalformedAtom(
+                                orig_atom,
+                                f"use dep defaults are not allowed in EAPI {eapi_obj}",
+                            )
+
                         # use defaults.
                         if x[-3:] in ("(+)", "(-)"):
                             x = x[:-3]
@@ -182,7 +188,7 @@ class atom(boolean.AndRestriction, metaclass=klass.generic_equality):
                 slot = None
             else:
                 slots = (slot,)
-                if eapi not in ("0", "1", "2", "3", "4"):
+                if eapi_obj.options.sub_slotting:
                     if slot[0:1] in ("*", "="):
                         if len(slot) > 1:
                             raise errors.MalformedAtom(

--- a/src/pkgcore/ebuild/domain.py
+++ b/src/pkgcore/ebuild/domain.py
@@ -132,7 +132,8 @@ def generate_filter(masks, unmasks, *extra):
 def _read_config_file(path):
     """Read all the data files under a given path."""
     try:
-        for fs_obj in iter_scan(path, follow_symlinks=True):
+        # sort based on location by default; this is to ensure 00 is before 01, and before a
+        for fs_obj in sorted(iter_scan(path, follow_symlinks=True)):
             if not fs_obj.is_reg or "/." in fs_obj.location:
                 continue
             for lineno, line in iter_read_bash(

--- a/src/pkgcore/ebuild/domain.py
+++ b/src/pkgcore/ebuild/domain.py
@@ -188,25 +188,25 @@ def load_property(
 class domain(config_domain):
 
     # XXX ouch, verify this crap and add defaults and stuff
-    _types = {
-        "profile": "ref:profile",
-        "repos": "lazy_refs:repo",
-        "vdb": "lazy_refs:repo",
-    }
-    for _thing in (
-        "root",
-        "config_dir",
-        "CHOST",
-        "CBUILD",
-        "CTARGET",
-        "CFLAGS",
-        "PATH",
-        "PORTAGE_TMPDIR",
-        "DISTCC_PATH",
-        "DISTCC_DIR",
-        "CCACHE_DIR",
-    ):
-        _types[_thing] = "str"
+    _types = dict.fromkeys(
+        (
+            "root",
+            "config_dir",
+            "CHOST",
+            "CBUILD",
+            "CTARGET",
+            "CFLAGS",
+            "PATH",
+            "PORTAGE_TMPDIR",
+            "DISTCC_PATH",
+            "DISTCC_DIR",
+            "CCACHE_DIR",
+        ),
+        "str",
+    )
+    _types["profile"] = "ref:profile"
+    _types["repos"] = "lazy_refs:repo"
+    _types["vdb"] = "lazy_refs:repo"
 
     # TODO this is missing defaults
     pkgcore_config_type = ConfigHint(
@@ -216,7 +216,7 @@ class domain(config_domain):
         allow_unknowns=True,
     )
 
-    del _types, _thing
+    del _types
 
     def __init__(
         self,

--- a/src/pkgcore/ebuild/domain.py
+++ b/src/pkgcore/ebuild/domain.py
@@ -44,6 +44,7 @@ from ..util.parserestrict import ParseError, parse_match
 from . import const
 from . import repository as ebuild_repo
 from .atom import atom as _atom
+from .eapi import get_latest_PMS_eapi
 from .misc import (
     ChunkedDataDict,
     chunked_data,
@@ -86,7 +87,10 @@ def package_use_splitter(iterable):
     USE_EXPAND target and should be expanded into their normalized/long form.
     """
 
+    eapi_obj = get_latest_PMS_eapi()
+
     def f(tokens: list[str]):
+
         i = iter(tokens)
         for idx, x in enumerate(i):
             if x.endswith(":"):
@@ -99,8 +103,12 @@ def package_use_splitter(iterable):
                         flag = f"-{x}_{flag[1:]}"
                     else:
                         flag = f"{x}_{flag}"
+                    if not eapi_obj.is_valid_use_flag(flag.lstrip("-")):
+                        raise ParseError(f"token {flag} is not a valid use flag")
                     l.append(flag)
                 return l
+            elif not eapi_obj.is_valid_use_flag(x.lstrip("-")):
+                raise ParseError(f"token {flag} is not a valid use flag")
         # if we made it here, there's no USE_EXPAND; thus just return the original sequence
         return tokens
 

--- a/src/pkgcore/ebuild/eapi.py
+++ b/src/pkgcore/ebuild/eapi.py
@@ -12,10 +12,19 @@ from snakeoil.mappings import ImmutableDict, OrderedFrozenSet, inject_getitem_as
 from snakeoil.osutils import pjoin
 from snakeoil.process.spawn import bash_version
 
+LATEST_PMS_EAPI_VER = "8"
+
+
+def get_latest_PMS_eapi():
+    """return the latest PMS EAPI object known to this version of pkgcore"""
+    return get_eapi(LATEST_PMS_EAPI_VER)
+
+
 from ..log import logger
 from . import atom, const
 
 demand_compile_regexp("_valid_EAPI_regex", r"^[A-Za-z0-9_][A-Za-z0-9+_.-]*$")
+demand_compile_regexp("_valid_use_flag", r"^[A-Za-z0-9][A-Za-z0-9+_@-]*$")
 
 eapi_optionals = ImmutableDict(
     {
@@ -460,6 +469,10 @@ class EAPI(metaclass=klass.immutable_instance):
         d["PKGCORE_EAPI_INHERITS"] = " ".join(x._magic for x in self.inherits)
         d["EAPI"] = self._magic
         return ImmutableDict(d)
+
+    def is_valid_use_flag(self, s: str) -> bool:
+        """returns True if the flag is parsable under this EAPI"""
+        return _valid_use_flag.match(s) is not None
 
 
 def get_eapi(magic, suppress_unsupported=True):

--- a/src/pkgcore/ebuild/eapi.py
+++ b/src/pkgcore/ebuild/eapi.py
@@ -52,6 +52,10 @@ eapi_optionals = ImmutableDict(
         "has_portdir": True,
         # Controls whether DESTTREE and INSDESTTREE are exported during src_install; see PMS.
         "has_desttree": True,
+        # Controls whether atoms support USE dependencies.
+        "has_use_deps": False,
+        # Controls wheter atoms support slot dependencies",
+        "has_slot_deps": False,
         # Controls whether ROOT, EROOT, D, and ED end with a trailing slash; see PMS.
         "trailing_slash": os.sep,
         # Controls whether SYSROOT, ESYSROOT, and BROOT are defined; see PMS.
@@ -105,6 +109,8 @@ eapi_optionals = ImmutableDict(
         "src_uri_renames": False,
         # Controls whether SRC_URI supports fetch+ and mirror+ prefixes.
         "src_uri_unrestrict": False,
+        # Controls whether strong blockers- hard deps of "things are broken after this merge" are supported for atom syntax.
+        "strong_blockers": False,
         # Controls whether or not use dependency atoms are able to control their enforced
         # value relative to another; standard use deps just enforce either on or off; EAPIs
         # supporting this allow syntax that can enforce (for example) X to be on if Y is on.
@@ -646,6 +652,7 @@ eapi1 = EAPI.register(
         eapi0.options,
         dict(
             iuse_defaults=True,
+            has_slot_deps=True,
         ),
     ),
     ebd_env_options=eapi0._ebd_env_options,
@@ -669,6 +676,8 @@ eapi2 = EAPI.register(
     optionals=_combine_dicts(
         eapi1.options,
         dict(
+            has_use_deps=True,
+            strong_blockers=True,
             doman_language_detect=True,
             transitive_use_atoms=True,
             src_uri_renames=True,

--- a/src/pkgcore/ebuild/ebd.py
+++ b/src/pkgcore/ebuild/ebd.py
@@ -788,7 +788,7 @@ class buildable(ebd, setup_mixin, format.build):
     def _setup_distfiles(self):
         # fetch distfiles
         if not self.verified_files:
-            ops = self.domain.pkg_operations(self.pkg, observer=self.observer)
+            ops = self.domain.get_pkg_operations(self.pkg, observer=self.observer)
             if ops.fetch():
                 # this break encapsulation and should be refactored.  Trace
                 # f35f2 and 6561eac for where this was refactored.

--- a/src/pkgcore/ebuild/misc.py
+++ b/src/pkgcore/ebuild/misc.py
@@ -598,7 +598,7 @@ def run_sanity_checks(pkgs, domain, threads=None):
     sanity_failures = defaultdict(list)
     # TODO: parallelize this across separate processes
     for pkg in pkgs:
-        pkg_ops = domain.pkg_operations(pkg)
+        pkg_ops = domain.get_pkg_operations(pkg)
         if pkg_ops.supports("sanity_check") and (failures := pkg_ops.sanity_check()):
             sanity_failures[pkg] = failures
     return sanity_failures

--- a/src/pkgcore/ebuild/portage_conf.py
+++ b/src/pkgcore/ebuild/portage_conf.py
@@ -357,8 +357,10 @@ class PortageConfig(DictMixin):
             hidden=False,
             backup=False,
         ):
+            had_repo_conf = False
             try:
                 with open(fp) as f:
+                    had_repo_conf = True
                     defaults, repo_confs = parser.parse_file(f)
             except PermissionError as e:
                 raise base_errors.PermissionDenied(fp, write=False) from e
@@ -375,8 +377,10 @@ class PortageConfig(DictMixin):
                 )
             main_defaults.update(defaults)
 
-            if not repo_confs:
-                logger.warning(f"repos.conf: parsing {fp!r}: file is empty")
+            if not had_repo_conf and not repo_confs:
+                logger.warning(
+                    f"repos.conf: not found, but should exist for modern support"
+                )
 
             for name, repo_conf in repo_confs.items():
                 if name in repos:

--- a/src/pkgcore/ebuild/processor.py
+++ b/src/pkgcore/ebuild/processor.py
@@ -739,8 +739,10 @@ class EbuildProcessor:
         for key, val in sorted(env_dict.items()):
             if key in self._readonly_vars:
                 continue
-            if not key[0].isalpha():
-                raise KeyError(f"{key}: bash doesn't allow digits as the first char")
+            if not key[0].isalpha() and not key.startswith("_"):
+                raise KeyError(
+                    f"{key}: bash doesn't allow digits or _ as the first char"
+                )
             if not isinstance(val, (str, list, tuple)):
                 raise ValueError(
                     f"_generate_env_str was fed a bad value; key={key}, val={val}"

--- a/src/pkgcore/ebuild/repository.py
+++ b/src/pkgcore/ebuild/repository.py
@@ -114,7 +114,7 @@ class repo_operations(_repo_ops.operations):
                 continue
 
             # fetch distfiles
-            pkg_ops = domain.pkg_operations(pkgs[0], observer=observer)
+            pkg_ops = domain.get_pkg_operations(pkgs[0], observer=observer)
             try:
                 if not pkg_ops.fetch(
                     list(fetchables.values()), observer, distdir=distdir

--- a/src/pkgcore/scripts/pconfig.py
+++ b/src/pkgcore/scripts/pconfig.py
@@ -421,7 +421,7 @@ def package_func(options, out, err):
     domain = options.domain
     for pkg in domain.installed_repos.combined.itermatch(options.query):
         matched = True
-        ops = domain.pkg_operations(pkg)
+        ops = domain.get_pkg_operations(pkg)
         if not ops.supports("configure"):
             out.write(f"package {pkg}: nothing to configure, ignoring")
             continue

--- a/src/pkgcore/scripts/pmerge.py
+++ b/src/pkgcore/scripts/pmerge.py
@@ -1140,7 +1140,7 @@ def main(options, out, err):
                 if not options.fetchonly and options.debug:
                     out.write("Forcing a clean of workdir")
 
-                pkg_ops = domain.pkg_operations(op.pkg, observer=build_obs)
+                pkg_ops = domain.get_pkg_operations(op.pkg, observer=build_obs)
                 out.write(
                     f"\n{len(op.pkg.distfiles)} file{pluralism(op.pkg.distfiles)} required-"
                 )
@@ -1172,7 +1172,7 @@ def main(options, out, err):
                         continue
                     pkg = result
                     cleanup.append(pkg.release_cached_data)
-                    pkg_ops = domain.pkg_operations(pkg, observer=build_obs)
+                    pkg_ops = domain.get_pkg_operations(pkg, observer=build_obs)
                     cleanup.append(buildop.cleanup)
 
                 cleanup.append(partial(pkg_ops.run_if_supported, "cleanup"))

--- a/tests/ebuild/test_domain.py
+++ b/tests/ebuild/test_domain.py
@@ -1,0 +1,56 @@
+from unittest import mock
+
+import pytest
+
+from pkgcore.ebuild import domain as domain_mod
+from pkgcore.ebuild import profiles
+from pkgcore.fs.livefs import iter_scan
+from pkgcore.restrictions import packages
+
+from .test_profiles import profile_mixin
+
+
+class TestDomain:
+    @pytest.fixture(autouse=True, scope="function")
+    def _setup(self, tmp_path_factory):
+        self.confdir = tmp_path_factory.mktemp("conf")
+        self.rootdir = tmp_path_factory.mktemp("root")
+        self.pmixin = profile_mixin()
+        self.profile_base = tmp_path_factory.mktemp("profiles")
+        self.profile1 = self.profile_base / "profile1"
+        self.pmixin.mk_profile(self.profile_base, str(self.profile1))
+
+    def mk_domain(self):
+        return domain_mod.domain(
+            profiles.OnDiskProfile(str(self.profile_base), "profile1"),
+            [],
+            [],
+            ROOT=self.rootdir,
+            config_dir=self.confdir,
+        )
+
+    def test_sorting(self):
+        """assert that configuration files are read in alphanum ordering"""
+        cdir = self.confdir / "package.use"
+        cdir.mkdir()
+
+        # assert the base state; no files, no content.
+        assert () == self.mk_domain().pkg_use
+
+        open(cdir / "00", "w").write("*/* X")
+        open(cdir / "01", "w").write("*/* -X Y")
+
+        # Force the returned ordering to be reversed; this is to assert that
+        # the domain forces a sort.
+        orig_func = iter_scan
+
+        def rev_iter_scan(*args, **kwargs):
+            return iter(sorted(orig_func(*args, **kwargs), reverse=True))
+
+        with mock.patch(
+            "pkgcore.fs.livefs.iter_scan", side_effect=rev_iter_scan
+        ), mock.patch("pkgcore.ebuild.domain.iter_scan", side_effect=rev_iter_scan):
+            assert (
+                (packages.AlwaysTrue, ((), ("X",))),
+                (packages.AlwaysTrue, (("X",), ("Y",))),
+            ) == self.mk_domain().pkg_use

--- a/tests/ebuild/test_domain.py
+++ b/tests/ebuild/test_domain.py
@@ -1,3 +1,4 @@
+import textwrap
 from unittest import mock
 
 import pytest
@@ -54,3 +55,30 @@ class TestDomain:
                 (packages.AlwaysTrue, ((), ("X",))),
                 (packages.AlwaysTrue, (("X",), ("Y",))),
             ) == self.mk_domain().pkg_use
+
+    def test_use_expand_syntax(self):
+        puse = self.confdir / "package.use"
+        puse.mkdir()
+        open(puse / "a", "w").write(
+            textwrap.dedent(
+                """
+                */* x_y1
+                # unrelated is there to verify that it's unaffected by the USE_EXPAND
+                */* unrelated X: -y1 y2
+                """
+            )
+        )
+
+        assert (
+            (packages.AlwaysTrue, ((), ("x_y1",))),
+            (
+                packages.AlwaysTrue,
+                (
+                    ("x_y1",),
+                    (
+                        "unrelated",
+                        "x_y2",
+                    ),
+                ),
+            ),
+        ) == self.mk_domain().pkg_use

--- a/tests/ebuild/test_portage_conf.py
+++ b/tests/ebuild/test_portage_conf.py
@@ -5,12 +5,12 @@ import stat
 import textwrap
 
 import pytest
+from snakeoil.osutils import pjoin
 
 from pkgcore import const
 from pkgcore import exceptions as base_errors
 from pkgcore.config import errors as config_errors
 from pkgcore.ebuild.portage_conf import PortageConfig
-from snakeoil.osutils import pjoin
 
 load_make_conf = PortageConfig.load_make_conf
 load_repos_conf = PortageConfig.load_repos_conf
@@ -77,11 +77,6 @@ class TestReposConf:
         path.chmod(stat.S_IWUSR)
         with pytest.raises(base_errors.PermissionDenied):
             load_repos_conf(path)
-
-    def test_blank_file(self, tmp_path, caplog):
-        (path := tmp_path / "file").touch()
-        load_repos_conf(path)
-        assert "file is empty" in caplog.text
 
     def test_garbage_file(self, tmp_path):
         (path := tmp_path / "file").write_bytes(binascii.b2a_hex(os.urandom(10)))


### PR DESCRIPTION
Being I'm in the 'kind of active and a lot of commits will follow', I'm posting the commit history here since github is shit about giving a proper summary:

commit 7a6178fb9feb4284cba6051aa0ab6d1408ce56c8 (HEAD -> master, origin/fixes-2022-12-25)
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 20:24:06 2022 -0800

    Ignore both empty and non-existant repos.conf files.
    
    Whilst this should probably matter, all reporting pathways I know of
    involve "don't yell at the user" this it's probably not optimal
    to have pathways that "yell at the user".
    
    close pkgcore/pkgcore#365
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit 783694c9846e842a3f81bbe076804944acb1f902
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 20:16:46 2022 -0800

    Throw an exception (py side) for any EBD var starting with '_'
    
    closes pkgcore/pkgcore#333
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>


commit ca654436ddd406987d06069a91020443e320bede
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 17:31:02 2022 -0800

    Add use flag validation for /etc/portage/package/package.use/* content.
    
    Had this been in place, it would've detected pkgcore/pkgcore#384 long ago.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit 4855702acd5c7460b46e972400e1d3a660be6de8
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 16:48:56 2022 -0800

    Expand EAPI object declarations of support, wire atom to use it.
    
    Specifically, this moves strong blockers, use deps, and slot deps to
    rely upon the EAPI context of the atom parse.  EAPI ultimately has say
    on this, thus just remove the 15+ year old hardcoded constants and use
    eapi_obj instead.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit 78edd86626c66a14bd2125cfda4256002baaecfe
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 16:32:13 2022 -0800

    Convert to eapi_obj usage for subslot/iuse defaults in atom parsing.
    
    We already paid the cost of looking up the eapi obj constants, thus use it,
    and remove the atom implementations awareness of magic eapi constants.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit 254ac2065287d48b8d4e0c92f879138e87eb5198
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 16:21:59 2022 -0800

    Move valid_use_flag parsing out of atom, rely upon eapi obj.
    
    EAPI objects are responsible for deciding the rules of how to parse
    atoms, and this extends to use flags.  Thus just ask the EAPI obj
    to tell us "is it valid?".
    
    In moving this out of atom.py it allows us to lace that validation
    into other configuration loading aspects of the code.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit ee0a47102ed2263ebebb404f21157193698d9f93
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 16:19:43 2022 -0800

    Add a constant of the latest PMS version, and add use flag validation to EAPI.
    
    Currently no EAPI varies the use flag parsing rules, but if it ever comes up,
    this will address it.
    
    In the process, this also will be used to move some logic out of atom.py whilst
    introducing the concept of 'latest PMS' as the 'latest' rules to parse under in
    the absense of an explicit directive.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit ef83b9eb6fc05797dd31c6d5c4b379b266391dc1
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 15:23:15 2022 -0800

    Add USE_EXPAND expansion awareness for /etc/portage/package.use/* files.
    
    Specifically, if you have:
    `*/* PYTHON_TARGETS: -python2_7 python3_9`
    
    Pkgcore was treating `PYTHON_TARGETS:` as a use flag.  That's obviously
    wrong, and the parsing should be tightened there.
    
    closes pkgcore/pkgcore#384
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit e8044cc9d82945a198bbf633a9979edd329f060d
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 14:50:50 2022 -0800

    Force stable sorting of /etc/portage/* files loading.
    
    Specifically, alphanumeric sorting; a '00' should always be
    parsed before an '01' or 'a'.
    
    The ordering must be stable so that globals- in a 00 file- can
    be overridden per package via other files.  If there is no stable
    ordering forced on how the order of files read, then this isn't supported.
    
    Closes pkgcore/pkgcore#385
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit 061d61423ced3a11c85d37cd11a27a287481438b
Author: Brian Harring <ferringb@gmail.com>
Date:   Sun Dec 25 13:20:57 2022 -0800

    Simplify some class attribute building.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit 90a558da25c0b2c1bc316ef9ff9f2f13fa72fac9
Author: Brian Harring <ferringb@gmail.com>
Date:   Tue Dec 20 22:39:36 2022 -0800

    Rename domain.pkg_operations to domain.get_pkg_operations
    
    Operations isn't a verb on it's own, so this naming isn't explanatory
    on it's own.  'get_pkg_operations'- plus a docstring- is clearer, thus
    the rename.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>
