### PR TITLE
minor sync cleanup: typing, logging, and burying file descriptions out of the API

### DIFF
--- a/src/pkgcore/sync/rsync.py
+++ b/src/pkgcore/sync/rsync.py
@@ -7,6 +7,7 @@ import os
 import socket
 import tempfile
 import time
+from itertools import islice
 
 from snakeoil.osutils import pjoin
 
@@ -142,7 +143,7 @@ class rsync_syncer(base.ExternalSyncer):
 
         # zip limits to the shortest iterable
         ret = None
-        for count, ip in zip(range(self.retries), self._get_ips()):
+        for ip in islice(self._get_ips(), self.retries):
             cmd = [
                 self.binary_path,
                 self.uri.replace(self.hostname, ip, 1),


### PR DESCRIPTION
commit 23a9857c9732012c3823e730ff658a11431ec194
Author: Brian Harring <ferringb@gmail.com>
Date:   Tue Jan 10 02:00:23 2023 -0800

    fix(sync): Add loggger.debug() of the sync command actually being invoked.
    
    Additionally, since we know the sync subsystem was written before basic sanity
    of the frontend, and we know that it invokes processes that write to stdout/stderr,
    force a flush of those handles to ensure that we don't wind up with interlaced output
    from two processes.
    
    The need to bury a flush here is a sign that the abstraction needs redesign, but
    that's a problem for a later date.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit ce43c7099d1ece48ea6fff5b9c733d0c8ab24930
Author: Brian Harring <ferringb@gmail.com>
Date:   Tue Jan 10 01:42:00 2023 -0800

    refactor(sync): hide FD passing as an internal thing.
    
    Effectively, add '_spawn' and '_spawn_interactive' to the base class,
    and expect consumers to invoke the appropriate one.
    
    This addition doesn't fully fix the fundamental lack of an observer (or log)
    based approach to getting info out of syncers, but it at least hides some of
    the internals so the syncer classes can do things like knowing what the
    correct encoding is for stdout, thus being able to write their own messages
    to it.
    
    TL;DR: This subsystem's interaction w/ CLI (and used as a library) needs rewriting,
    this just reduces that problem when we visit it.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>

commit fd03c411fe9c919cc37f888539c5a8f77f93e007
Author: Brian Harring <ferringb@gmail.com>
Date:   Tue Jan 10 01:36:48 2023 -0800

    refactor(sync): Remove unused variable assignment.
    
    We loop over the zip'd ips, but don't care about the actual
    idx.
    
    Signed-off-by: Brian Harring <ferringb@gmail.com>
