### PR TITLE
domain: support `-*` in use as previous removal

### DIFF
--- a/src/pkgcore/ebuild/misc.py
+++ b/src/pkgcore/ebuild/misc.py
@@ -66,8 +66,14 @@ def optimize_incrementals(sequence):
                 finalized.add(item)
 
 
-def incremental_chunked(orig, iterables):
+def incremental_chunked(orig: set[str], iterables):
     for cinst in iterables:
+        if "*" in cinst.neg:  # remove all previous set flags
+            orig.clear()
+        for flag in cinst.neg:
+            if flag.endswith("_*"):  # remove previous USE_EXPAND
+                drop = [f for f in orig if f.startswith(flag[:-2])]
+                orig.difference_update(drop)
         orig.difference_update(cinst.neg)
         orig.update(cinst.pos)
 

--- a/tests/ebuild/test_domain.py
+++ b/tests/ebuild/test_domain.py
@@ -57,15 +57,17 @@ class TestDomain:
 
     def test_use_expand_syntax(self):
         (self.pusedir / "a").write_text(
-            textwrap.dedent(
-                """
-                */* x_y1
-                # unrelated is there to verify that it's unaffected by the USE_EXPAND
-                */* unrelated X: -y1 y2
-                # multiple USE_EXPANDs
-                */* unrelated X: -y1 y2 Z: -z3 z4
-                """
-            )
+            """
+            */* x_y1
+            # unrelated is there to verify that it's unaffected by the USE_EXPAND
+            */* unrelated X: -y1 y2
+            # multiple USE_EXPANDs
+            */* unrelated X: -y1 y2 Z: -z3 z4
+            # cleanup previous
+            */* x y -* z
+            # cleanup previous USE_EXPAND
+            */* unrelated Y: y1 -* y2 Z: z1 -* -z2
+            """
         )
 
         assert (
@@ -88,6 +90,27 @@ class TestDomain:
                         "unrelated",
                         "x_y2",
                         "z_z4",
+                    ),
+                ),
+            ),
+            (
+                packages.AlwaysTrue,
+                (
+                    ("*",),
+                    ("z",),
+                ),
+            ),
+            (
+                packages.AlwaysTrue,
+                (
+                    (
+                        "y_*",
+                        "z_*",
+                        "z_z2",
+                    ),
+                    (
+                        "unrelated",
+                        "y_y2",
                     ),
                 ),
             ),


### PR DESCRIPTION
Add support for `-*` and `USE_EXPAND: -*` syntax. Allow this syntax, and update incremental computation of resulting use combination.

Resolves: https://github.com/pkgcore/pkgcore/issues/393

### Notes

I'm not sure I've solved it in the ideal way, on the fast way. From multiple tests, it seems to work, but this part of pkgcore is still hard for me to understand (especially the change in `incremental_chunked`).