### PR TITLE
data/xml-schema/metadata.xsd: Add kde-invent remote-id type

### DIFF
--- a/data/share/pkgcore/xml-schema/metadata.xsd
+++ b/data/share/pkgcore/xml-schema/metadata.xsd
@@ -284,6 +284,7 @@
 			<xs:enumeration value='google-code'/>
 			<xs:enumeration value='hackage'/>
 			<xs:enumeration value='heptapod'/>
+			<xs:enumeration value='kde-invent'/>
 			<xs:enumeration value='launchpad'/>
 			<xs:enumeration value='osdn'/>
 			<xs:enumeration value='pear'/>


### PR DESCRIPTION
This follows an earlier update of the DTD, commit bb286dbef6af03bd7d063cf693f9860419796c3d in data/dtd.git.

Taken from proj/xml-schema.git commit 84d4fe3e11bc21c3d5742be1a04ba0df33c7bd0c..