### PR TITLE
econf matches configure --help output better

### DIFF
--- a/data/lib/pkgcore/ebd/eapi/4/src_configure.bash
+++ b/data/lib/pkgcore/ebd/eapi/4/src_configure.bash
@@ -1,5 +1,5 @@
 __econf_options_eapi4() {
-	if [[ $1 == *"--disable-dependency-tracking"* ]]; then
+	if [[ $1 == *--disable-dependency-tracking[^A-Za-z0-9+_.-]* ]]; then
 		echo --disable-dependency-tracking
 	fi
 }

--- a/data/lib/pkgcore/ebd/eapi/5/src_configure.bash
+++ b/data/lib/pkgcore/ebd/eapi/5/src_configure.bash
@@ -1,5 +1,5 @@
 __econf_options_eapi5() {
-	if [[ $1 == *"--disable-silent-rules"* ]]; then
+	if [[ $1 == *--disable-silent-rules[^A-Za-z0-9+_.-]* ]]; then
 		echo --disable-silent-rules
 	fi
 }

--- a/data/lib/pkgcore/ebd/eapi/7/src_configure.bash
+++ b/data/lib/pkgcore/ebd/eapi/7/src_configure.bash
@@ -1,5 +1,5 @@
 __econf_options_eapi7() {
-	if [[ $1 == *"--with-sysroot"* ]]; then
+	if [[ $1 == *--with-sysroot[^A-Za-z0-9+_.-]* ]]; then
 		echo --with-sysroot="${ESYSROOT:-/}"
 	fi
 }


### PR DESCRIPTION
Check for proper end of string for all option names beginning with "with-", "disable-" or "enable-". This mainly affects --with-sysroot, where false positives have been observed.

This follows this retroactive change in PMS:
https://gitweb.gentoo.org/proj/pms.git/commit/?id=0e311ca4ac75be6ebea2a0b3c1b46f4daac75190 which was approved by the Gentoo Council in its 2023-04-09 meeting.

CC @SoapGentoo
