### PR TITLE
fix missing errors when all ebuilds for package are masked bad

### DIFF
--- a/src/pkgcore/ebuild/repository.py
+++ b/src/pkgcore/ebuild/repository.py
@@ -171,7 +171,9 @@ class repo_operations(_repo_ops.operations):
                 # might be noteworthy. Errors for one or more dependencies are
                 # reported below that.
                 if pkg.key not in missed_bad_set:
-                    observer.error(f"Warning: It is possible that all dependencies for {pkg.key} are bad.")
+                    observer.error(
+                        f"Warning: It is possible that all dependencies for {pkg.key} are bad."
+                    )
                 exc = pkg.data
                 error_str = f"{pkg.cpvstr}: {exc.msg(verbosity=observer.verbosity)}"
                 observer.error(error_str)


### PR DESCRIPTION
Fixes https://github.com/pkgcore/pkgdev/issues/55

If all of a package's ebuild files have been masked bad, that package gets filtered out of the iterator for the previous loop in this function, so a followup loop over the masked bad packages can help to emit the unreported errors. The commit adds an extra warning message about the edge case, which may not be necessary.

Co-authored-by: @zhuyifei1999