### PR TITLE
Misc minor cleanup/fixes

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -44,6 +44,7 @@ jobs:
         path: build/sphinx/html
 
   deploy:
+    if: github.repository == 'pkgcore/pkgcore'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.rst
+++ b/README.rst
@@ -55,11 +55,11 @@ Installing from a tarball::
 Tests
 =====
 
-A standalone test runner is integrated in setup.py; to run, just execute::
+Standard python test runners can be used, for example:
 
-    python setup.py test
+    pytest -v
 
-In addition, a tox config is provided so the testsuite can be run in a
+A tox config is provided so the testsuite can be run in a
 virtualenv setup against all supported python versions. To run tests for all
 environments just execute **tox** in the root directory of a repo or unpacked
 tarball. Otherwise, for a specific python version execute something similar to

--- a/src/pkgcore/repository/util.py
+++ b/src/pkgcore/repository/util.py
@@ -13,19 +13,19 @@ from . import multiplex, prototype, virtual
 
 
 class SimpleTree(prototype.tree):
-    """Fake, in-memory repository.
-
-    Args:
-        cpv_dict (dict): CPVs to populate the repo with
-        pkg_klass: class of packages in repo
-        livefs (bool): regular repo if False, vdb if True
-        frozen (bool): repo is modifiable if False, otherwise readonly
-        repo_id (str): repo ID
-    """
+    """in-memory repository used for testing or simple shims."""
 
     def __init__(
         self, cpv_dict, pkg_klass=None, livefs=False, frozen=True, repo_id=None
     ):
+        """
+        Args:
+            cpv_dict (dict): CPVs to populate the repo with
+            pkg_klass: class of packages in repo
+            livefs (bool): regular repo if False, vdb if True
+            frozen (bool): repo is modifiable if False, otherwise readonly
+            repo_id (str): repo ID
+        """
         self.cpv_dict = cpv_dict
         if pkg_klass is None:
             pkg_klass = VersionedCPV

--- a/src/pkgcore/scripts/pquery.py
+++ b/src/pkgcore/scripts/pquery.py
@@ -16,6 +16,7 @@ running them on source repos makes no sense.
 import errno
 import os
 from functools import partial
+import typing
 
 from snakeoil.cli import arghparse
 from snakeoil.formatters import decorate_forced_wrapping
@@ -35,9 +36,17 @@ from ..util import parserestrict
 class DataSourceRestriction(values.base):
     """Turn a data_source into a line iterator and apply a restriction."""
 
-    def __init__(self, childrestriction, **kwargs):
+    __slots__ = ("negate", "restriction")
+
+    def __init__(
+        self,
+        childrestriction: typing.Union[values.base, values.AnyMatch],
+        negate=False,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
-        self.restriction = childrestriction
+        object.__setattr__(self, "restriction", childrestriction)
+        object.__setattr__(self, "negate", negate)
 
     def __str__(self):
         return f"DataSourceRestriction: {self.restriction} negate={self.negate}"
@@ -929,9 +938,11 @@ def parse_maintainer_email(value):
 
 
 @bind_add_query(
-    "--environment", action="append", help="regexp search in environment.bz2"
+    "--environment-re",
+    action="append",
+    help="regexp search of lines in environment.bz2",
 )
-def parse_envmatch(value):
+def parse_environment_re(value):
     """Apply a regexp to the environment."""
     return packages.PackageRestriction(
         "environment", DataSourceRestriction(values.AnyMatch(values.StrRegex(value)))

--- a/src/pkgcore/scripts/pquery.py
+++ b/src/pkgcore/scripts/pquery.py
@@ -871,7 +871,7 @@ def parse_ownsre(value):
 @bind_add_query("--maintainer", action="append", help="regex to search for maintainers")
 def parse_maintainer(value):
     """
-    Case insensitive Regex match on the combined 'name <email>' bit of
+    Case-insensitive Regex match on the combined 'name <email>' bit of
     metadata.xml's maintainer data.
     """
     if value and value != "maintainer-needed":
@@ -895,7 +895,7 @@ def parse_maintainer(value):
 )
 def parse_maintainer_name(value):
     """
-    Case insensitive Regex match on the name bit of metadata.xml's
+    Case-insensitive Regex match on the name bit of metadata.xml's
     maintainer data.
     """
     return packages.PackageRestriction(
@@ -915,7 +915,7 @@ def parse_maintainer_name(value):
 )
 def parse_maintainer_email(value):
     """
-    Case insensitive Regex match on the email bit of metadata.xml's
+    Case-insensitive Regex match on the email bit of metadata.xml's
     maintainer data.
     """
     return packages.PackageRestriction(


### PR DESCRIPTION
* fix pquery --environment (rename it in the process
* update README test instructions
* update github workflow to not run doc deploy on forks
* minor docstring and typo cleanup.

More to follow for the type annotations and pquery tests, this is just me depiling the simple stuff while I'm spinning back up.