### PR TITLE
tighten CPV parsing to disallow revisions as part of the package name

### DIFF
--- a/src/pkgcore/ebuild/atom.py
+++ b/src/pkgcore/ebuild/atom.py
@@ -99,7 +99,8 @@ class atom(boolean.AndRestriction, metaclass=klass.generic_equality):
         orig_atom = atom
         override_kls = False
         use_start = atom.find("[")
-        slot_start = atom.find(":")
+        # ensure slot or repo anchoring is left of use flags.
+        slot_start = atom.find(":", 0, use_start)
         eapi_obj = eapi_mod.get_eapi(
             eapi if eapi != "-1" else eapi_mod.LATEST_PMS_EAPI_VER
         )

--- a/src/pkgcore/ebuild/cpv.py
+++ b/src/pkgcore/ebuild/cpv.py
@@ -38,11 +38,11 @@ def isvalid_pkg_name(chunks):
     if not all(not s or _pkg_re.match(s) for s in chunks):
         return False
     # the package name must not end with a hyphen followed by anything that
-    # looks like a version -- need to ensure that we've gotten more than one
+    # looks like a version or revision -- need to ensure that we've gotten more than one
     # chunk, i.e. at least one hyphen
-    if len(chunks) > 1 and isvalid_version_re.match(chunks[-1]):
-        return False
-    return True
+    if len(chunks) == 1:
+        return True
+    return not (isvalid_version_re.match(chunks[-1]) or isvalid_rev(chunks[-1]))
 
 
 def isvalid_rev(s: str):

--- a/tests/ebuild/test_atom.py
+++ b/tests/ebuild/test_atom.py
@@ -123,6 +123,7 @@ class TestAtom(TestRestriction):
         self.assertMatch(a, CPV.unversioned("kde-base/kde"))
         self.assertNotMatch(a, CPV.unversioned("kde-base/kde2"))
         self.assertMatch(a, CPV.versioned("kde-base/kde-3"))
+        pytest.raises(errors.MalformedAtom, self.kls, "foo/bar-11-r3")
 
     def make_atom(self, s, ops, ver):
         l = []

--- a/tests/ebuild/test_cpv.py
+++ b/tests/ebuild/test_cpv.py
@@ -52,6 +52,7 @@ class TestCPV:
         "+dfa",
         "timidity--9f",
         "ormaybe---13_beta",
+        "bar-11-r3",
     )
 
     good_cp = (


### PR DESCRIPTION
This adds tests for CPV to catch `foo/bar-11-r3` treating `bar-11-r3` as a package name due to it not checking for trailing revisions, just versions.  This also adds a redundant assertion in atom parsing to ensure CPV changes don't regress the atom parsing.

This just fixes a tangential parsing issue spotted while looking at #419 ; it doesn't resolve the design choice for that.