### PR TITLE
fix: tweak CPV parsing rules to match PMS.

### DIFF
--- a/src/pkgcore/ebuild/cpv.py
+++ b/src/pkgcore/ebuild/cpv.py
@@ -42,7 +42,12 @@ def isvalid_pkg_name(chunks):
     # chunk, i.e. at least one hyphen
     if len(chunks) == 1:
         return True
-    return not (isvalid_version_re.match(chunks[-1]) or isvalid_rev(chunks[-1]))
+    if isvalid_version_re.match(chunks[-1]):
+        return False
+    if len(chunks) >= 3 and isvalid_rev(chunks[-1]):
+        # if the last chunk is a revision, the proceeding *must not* be version like.
+        return not isvalid_version_re.match(chunks[-2])
+    return True
 
 
 def isvalid_rev(s: str):

--- a/tests/ebuild/test_cpv.py
+++ b/tests/ebuild/test_cpv.py
@@ -64,6 +64,7 @@ class TestCPV:
         "bah/f-100dpi",
         "dev-util/diffball-blah-monkeys",
         "virtual/7z",
+        "x11-drivers/xf86-video-r128",
     )
 
     good_vers = ("1", "2.3.4", "2.3.4a", "02.3", "2.03", "3d", "3D")


### PR DESCRIPTION
Bug #421 captures this; pkgcore was allowing version components as the package name if it was suffixed by a revision; the fix for that incorrectly limited a package name that has a trailing revision, but *no version syntax* in the name.

This commit just refactors the revision check to also force a check for a leading version if revision-like is found.