### PR TITLE
Hygenic test fix + repository typing cleanup + fixes

### DIFF
--- a/src/pkgcore/pytest/plugin.py
+++ b/src/pkgcore/pytest/plugin.py
@@ -41,6 +41,8 @@ class GitRepo:
                 self.add(pjoin(self.path, ".init"), create=True)
 
     def run(self, cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **kwargs):
+        env = os.environ.copy()
+        env["HOME"] = self.path
         return subprocess.run(
             cmd,
             cwd=self.path,
@@ -48,6 +50,7 @@ class GitRepo:
             check=True,
             stdout=stdout,
             stderr=stderr,
+            env=env,
             **kwargs,
         )
 

--- a/src/pkgcore/repository/configured.py
+++ b/src/pkgcore/repository/configured.py
@@ -6,6 +6,7 @@ __all__ = ("tree",)
 
 from functools import partial
 
+import snakeoil.klass
 from snakeoil.klass import DirProxy, GetAttrProxy
 
 from ..operations.repo import operations_proxy
@@ -47,6 +48,11 @@ class tree(prototype.tree):
     def pkg_masks(self):
         # required to override empty pkg_masks inherited from prototype.tree
         return self.raw_repo.pkg_masks
+
+    # add explicit alises to 'show' ABCMeta that the methods are addressed.
+    _get_categories = snakeoil.klass.alias_method("raw_repo._get_categories")
+    _get_packages = snakeoil.klass.alias_method("raw_repo._get_packages")
+    _get_versions = snakeoil.klass.alias_method("raw_repo._get_versions")
 
     __getattr__ = GetAttrProxy("raw_repo")
     __dir__ = DirProxy("raw_repo")

--- a/src/pkgcore/repository/filtered.py
+++ b/src/pkgcore/repository/filtered.py
@@ -5,12 +5,15 @@ filtering repository
 __all__ = ("tree",)
 
 from itertools import filterfalse
+import typing
 
-from snakeoil.klass import DirProxy, GetAttrProxy
+from snakeoil.klass import DirProxy, GetAttrProxy, alias_method
 
 from ..operations.repo import operations_proxy
 from ..restrictions import restriction
 from . import errors, prototype
+from pkgcore.ebuild.restricts import CategoryDep
+from pkgcore.ebuild.atom import atom
 
 
 class tree(prototype.tree):
@@ -33,6 +36,7 @@ class tree(prototype.tree):
             self._filterfunc = filter
         else:
             self._filterfunc = filterfalse
+        super().__init__()
 
     def itermatch(self, restrict, **kwds):
         # note that this lets the repo do the initial filtering.
@@ -53,6 +57,22 @@ class tree(prototype.tree):
         for i in self:
             count += 1
         return count
+
+    # note: for the _get_* methods they use itermatch which would typically
+    # be a cycle; this class's itermatch is fully reliant on the raw repo
+    # thus no cycle.
+
+    # TODO: add support for .{category,package,version}.force_regen via custom class.  No code relies upon this,
+    # but that functionality missing means the implementation has a known potential for developing a stale cache.
+    _get_categories = alias_method("raw_repo.categories.__iter__")
+
+    def _get_packages(self, category: str) -> typing.Iterable[str]:
+        for package in self.raw_repo.packages[category]:
+            if any(self.itermatch(atom(f"{category}/{package}"))):
+                yield package
+
+    def _get_versions(self, catpkg: tuple[str, str]) -> typing.Iterable[str]:
+        return (pkg.fullver for pkg in self.itermatch(atom(f"{catpkg[0]}/{catpkg[1]}")))
 
     __getattr__ = GetAttrProxy("raw_repo")
     __dir__ = DirProxy("raw_repo")

--- a/src/pkgcore/repository/prototype.py
+++ b/src/pkgcore/repository/prototype.py
@@ -54,7 +54,7 @@ class PackageMapping(DictMixin):
             return o
         if key not in self._parent:
             raise KeyError(key)
-        self._cache[key] = vals = self._pull_vals(key)
+        self._cache[key] = vals = tuple(self._pull_vals(key))
         return vals
 
     def keys(self):
@@ -79,7 +79,7 @@ class VersionMapping(DictMixin):
             return o
         if not key[1] in self._parent.get(key[0], ()):
             raise KeyError(key)
-        val = self._pull_vals(key)
+        val = tuple(self._pull_vals(key))
         self._cache[key] = val
         return val
 
@@ -141,18 +141,20 @@ class tree(abc.ABC):
         raise NotImplementedError(self, "configure")
 
     @abc.abstractmethod
-    def _get_categories(self):
-        """this must return a list, or sequence"""
+    def _get_categories(self) -> frozenset[str] | typing.Iterable[str]:
+        """this must return an iterable or tuple of this repo's categories"""
         raise NotImplementedError(self, "_get_categories")
 
     @abc.abstractmethod
-    def _get_packages(self, category):
-        """this must return a list, or sequence"""
+    def _get_packages(self, category: str) -> tuple[str] | typing.Iterable[str]:
+        """Receives category and must return the packages of that cat.  Converted to tuple"""
         raise NotImplementedError(self, "_get_packages")
 
     @abc.abstractmethod
-    def _get_versions(self, package):
-        """this must return a list, or sequence"""
+    def _get_versions(
+        self, package: tuple[str, str]
+    ) -> tuple[str] | typing.Iterable[str]:
+        """Receives (cat/pkg) and must return the cp versions.  Converted to tuple"""
         raise NotImplementedError(self, "_get_versions")
 
     def __getitem__(self, cpv):

--- a/src/pkgcore/repository/prototype.py
+++ b/src/pkgcore/repository/prototype.py
@@ -15,6 +15,7 @@ from ..ebuild.atom import atom
 from ..operations import repo
 from ..restrictions import boolean, packages, restriction, values
 from ..restrictions.util import collect_package_restrictions
+import abc
 
 
 class CategoryLazyFrozenSet:
@@ -94,8 +95,8 @@ class VersionMapping(DictMixin):
             self._cache.pop(key, None)
 
 
-class tree:
-    """Template for all repository variants.
+class tree(abc.ABC):
+    """ABC for all repository variants.
 
     Args:
         frozen (bool): controls whether the repository is mutable or immutable
@@ -139,14 +140,17 @@ class tree:
         """Return a configured form of the repository."""
         raise NotImplementedError(self, "configure")
 
+    @abc.abstractmethod
     def _get_categories(self):
         """this must return a list, or sequence"""
         raise NotImplementedError(self, "_get_categories")
 
+    @abc.abstractmethod
     def _get_packages(self, category):
         """this must return a list, or sequence"""
         raise NotImplementedError(self, "_get_packages")
 
+    @abc.abstractmethod
     def _get_versions(self, package):
         """this must return a list, or sequence"""
         raise NotImplementedError(self, "_get_versions")

--- a/tests/repository/test_filtered.py
+++ b/tests/repository/test_filtered.py
@@ -1,4 +1,5 @@
 from pkgcore.ebuild.atom import atom
+from pkgcore.ebuild.restricts import CategoryDep
 from pkgcore.ebuild.cpv import VersionedCPV
 from pkgcore.repository import filtered
 from pkgcore.repository.util import SimpleTree
@@ -57,3 +58,24 @@ class TestVisibility:
             )
         )
         assert sorted(vrepo) == sorted(repo.itermatch(atom("dev-util/bsdiff")))
+
+    def test_categories_api(self):
+        # filter to just dev-util/diffball; this confirms that empty categories are filter,
+        # and that filtering of a package (leaving one in a category still) doesn't filter the category.
+        _, vrepo = self.setup_repos(
+            packages.OrRestriction(CategoryDep("dev-lib"), atom("dev-util/bsdiff"))
+        )
+        assert sorted(vrepo.categories) == sorted(
+            [
+                "dev-lib",
+                "dev-util",
+            ]
+        ), "category filtering must not filter dev-lib even if there are no packages left post filtering"
+
+    def test_packages_api(self):
+        _, vrepo = self.setup_repos(atom("dev-util/diffball"))
+        assert sorted(vrepo.packages["dev-util"]) == ["bsdiff"]
+
+    def test_versions_api(self):
+        _, vrepo = self.setup_repos(atom("=dev-util/diffball-1.0"))
+        assert sorted(vrepo.versions[("dev-util", "diffball")]) == ["0.7"]


### PR DESCRIPTION
The commits carry detailed info for each change.  Summarizing:
* Downstream usage of the pytest plugin had assumption about environment hygiene ($HOME being sanitized) that wasn't true.  That's fixed.  That primarily impacted test validation of pkgdev.
* Repository prototype as converted to an ABC so any derivatives that don't override abstract methods get flagged; both filtered (actually broke) and configured (false positive, but best to be explicit) were caught via this.
* * For filtered, the `.{category,package,versions}` API was broken via `super().__init__()` not being invoked.  This is fixed, and proper implementations of the underlying `_get_.*` methods was added, along with tests.
*  `prototype.tree._get_{category,packages,versions}` had a requirement that child implementations return the results in an immutable form.  This is begging for a bug; instead, accept either an immutable or an iterable, and within the ABC *enforce* it as immutable.  For implementations that already returned immutable, this is effectively a noop- `tuple(some_tuple)` returns `some_tuple` w/out creating a new one, as does frozenset.
