### PR TITLE
fix: tox.ini since it's not been used in ages.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,22 @@
 [tox]
-envlist = py38, py39, py310, py311, py312
+envlist = py310, py311, py312
 [testenv]
 # force latest virtualenv/pip
 download = true
-deps = -rrequirements/tox.txt
+extras = test
 commands =
 	pytest --cov {posargs:-v}
 
 # build docs
 [testenv:docs]
 skip_install = true
-deps =
-	-rrequirements/dev.txt
-	-rrequirements/docs.txt
+extras = doc
 commands =
 	python setup.py build_docs
 
 # build dist files
 [testenv:dist]
 skip_install = true
-deps = -rrequirements/dist.txt
 commands =
 	python setup.py sdist
 	python setup.py bdist_wheel


### PR DESCRIPTION
This broke whenever the repo went to pyproject.toml .

On the one hand, I like enumerating what devs have to invoke locally rather than relying on GH.

On the other hand, clearly no one is using this.

This fixes it for current usage.  If it's to continue, then GH and tox envlist's should be fused.