### PR TITLE
Correct fix intersphinx doc linkage, automate maintenance of it.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -253,8 +253,8 @@ epub_copyright = copyright
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://docs.python.org/", None),
-    "snakeoil": ("https://github.com/pkgcore/snakeoil", None),
+    "python": ("https://docs.python.org/3", None),
+    "snakeoil": ("https://pkgcore.github.io/snakeoil", None),
 }
 autodoc_default_flags = [
     "members",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = {file = "LICENSE"}
 requires-python = "~=3.10"
 # alphabetical order.
 authors = [
-	{name = "Michał Górny"},
+	{name = "Michał Górny", email = "mgorny@gentoo.org"},
 	{name = "Tim Harder", email = "radhermit@gmail.com"},
 	{name = "Brian Harring", email = "ferringb@gmail.com"},
 	{name = "Arthur Zamarin", email = "arthurzam@gentoo.org"},


### PR DESCRIPTION
intersphinx is used to do linkage between projects- pkgcore referring to snakeoil documentation for example.

These links are long since old/dead, thus need fixing.

See https://github.com/pkgcore/pkgcore/actions/runs/7656999844/job/20874145430 for an example of the failure.