### PR TITLE
Lock black version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,7 +148,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - uses: psf/black@stable
+    - name: Install black version
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[formatter]
+        black --check --diff .
 
   gentoo-regen:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ clean:
 .PHONY: format
 format:
 	$(PYTHON) -m black .
+
+.PHONY: dev-environment
+dev-environment:
+	$(PYTHON) -m pip install -e .[test,doc,formatter]

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,14 @@ Installing from a tarball::
 
     pip install .
 
+Developing
+==========
+
+Installing the dependencies for testing, formatting, and documentation building
+into an editable environment::
+
+    make dev-environment
+
 Tests
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ doc = [
 	"sphinx",
 	"tomli; python_version < '3.11'"
 ]
+formatter = [
+	"black ~= 24.1"
+]
 
 [project.urls]
 Homepage = "https://github.com/pkgcore/pkgcore"


### PR DESCRIPTION
Two changes:
* wire the GH black formatter test to use whatever version we have in pyproject.toml under the optional 'formatter'.
* Add a make target of `dev-environment` so that's all people have to know to invoke to get the relevant dev tooling (formatting, docs, tests)