### PR TITLE
bash-completion: suppress error message outside git repository

### DIFF
--- a/data/share/bash-completion/completions/pquery
+++ b/data/share/bash-completion/completions/pquery
@@ -90,7 +90,7 @@ _pquery() {
     )
 
     # find repo location
-    local REPO="$(git rev-parse --show-toplevel)"
+    local REPO="$(git rev-parse --show-toplevel 2>/dev/null)"
     for ((i = 1; i < ${COMP_CWORD}; i++)); do
         case "${COMP_WORDS[i]}" in
             -r | --repo)
@@ -146,7 +146,7 @@ _pquery() {
                 COMPREPLY+=($(compgen -W "${base_options[*]}" -- "${cur}"))
             else
                 _list_repo_atoms() {
-                    eval cd "${REPO}" || return
+                    eval cd "${REPO}" 2>/dev/null || return
                     if [[ $cur == */* ]]; then
                         compgen -W "$(compgen -G "${cur}*" )" -- "${cur}"
                     else


### PR DESCRIPTION
This is a fix for the completion setting at `data/share/bash-completion/completions/pquery`.

### Problem

With the bash-completion setting in the current `master` branch, when the current working directory is outside any git repositories, an attempt of a TAB completion for the command `pquery` produces the error message. This breaks the cursor position maintained by Bash/Readline, and the later editing of the command line becomes broken until the screen is cleared by <kbd>C-l</kbd>.

This problem becomes more significant with a framework of autosuggestions (which calls Bash's programmable completions in the background while the user inputs commands) as reported at https://github.com/akinomyoga/ble.sh/issues/487. It becomes almost impossible to edit the command.

### Repeat-by

After setting up the `pquery` completion for `bash-completion` and loading `bash-completion` in a fresh Bash interactive session, one can input `pquery s` outside any git repositories and attempt a TAB completion by pressing `TAB`:

```bash
$ pquery s[TAB]
````

As a result, the following error message (*fatal: not a git repository (or any of the parent directories): .git\<newline>*) is shown, which is not expected.

```bash
$ pquery sfatal: not a git repository (or any of the parent directories): .git
asdfasdf    <-- subsequent user input "asdfasdf" is printed on the next line instead of after "pquery s"
```

The cursor position in the terminal changes to the beginning of the next line, yet Bash internally considers the cursor is just after "s" in the command-line string `pquery s`. This inconsistency causes an issue in the line editing.

### Solution

When the completion setting attempts to extract the information using the `git` command, the standard error should be redirected to `/dev/null`. There is another line, where a possible failure is considered but `stderr` is not redirected, which should also be fixed the same way.
