### PR TITLE
tests: Wrap partial() in staticmethod(), in attributes for py3.14

### DIFF
--- a/tests/ebuild/test_profiles.py
+++ b/tests/ebuild/test_profiles.py
@@ -787,7 +787,7 @@ class TestPortage1ProfileNode(TestPmsProfileNode):
         ]
     )
 
-    klass = partial(TestPmsProfileNode.klass, pms_strict=False)
+    klass = staticmethod(partial(TestPmsProfileNode.klass, pms_strict=False))
 
     def write_file(self, tmp_path, filename, text, profile=None):
         if filename not in self.can_be_dirs:

--- a/tests/restrictions/test_restriction.py
+++ b/tests/restrictions/test_restriction.py
@@ -47,7 +47,7 @@ class TestBase(TestRestriction):
 
 
 class TestAlwaysBool(TestRestriction):
-    bool_kls = partial(restriction.AlwaysBool, "foo")
+    bool_kls = staticmethod(partial(restriction.AlwaysBool, "foo"))
 
     def test_true(self):
         true_r = self.bool_kls(True)

--- a/tests/restrictions/test_values.py
+++ b/tests/restrictions/test_values.py
@@ -306,7 +306,7 @@ class TestEqualityMatch(TestRestriction):
 
 
 class TestContainmentMatch(TestRestriction):
-    kls = partial(values.ContainmentMatch, disable_inst_caching=True)
+    kls = staticmethod(partial(values.ContainmentMatch, disable_inst_caching=True))
 
     def test_match(self):
         for x, y, ret in (


### PR DESCRIPTION
Wrap `partial()` uses in class attributes in `staticmethod()`, as required for them to work correctly in Python 3.14.

> functools.partial is now a method descriptor. Wrap it in staticmethod()
> if you want to preserve the old behavior.

(https://docs.python.org/3.14/whatsnew/3.14.html#changes-in-the-python-api)