### PR TITLE
pkgcore: profiles: use ProfileNode for base profile

### DIFF
--- a/src/pkgcore/ebuild/profiles.py
+++ b/src/pkgcore/ebuild/profiles.py
@@ -910,7 +910,7 @@ class OnDiskProfile(ProfileStack):
     def stack(self):
         l = ProfileStack.stack.function(self)
         if self.load_profile_base:
-            l = (EmptyRootNode._autodetect_and_create(self.basepath),) + l
+            l = (ProfileNode._autodetect_and_create(self.basepath),) + l
         return l
 
     @klass.jit_attr

--- a/src/pkgcore/ebuild/profiles.py
+++ b/src/pkgcore/ebuild/profiles.py
@@ -1,7 +1,6 @@
 __all__ = (
     "ProfileError",
     "ProfileNode",
-    "EmptyRootNode",
     "OnDiskProfile",
     "UserProfile",
 )
@@ -617,20 +616,6 @@ class ProfileNode(metaclass=caching.WeakInstMeta):
         # optimization to avoid re-parsing what we already did.
         object.__setattr__(profile, "_repoconfig", repo_config)
         return profile
-
-
-class EmptyRootNode(ProfileNode):
-    __inst_caching__ = True
-
-    parents = ()
-    deprecated = None
-    pkg_use = masked_use = stable_masked_use = forced_use = stable_forced_use = (
-        misc.ChunkedDataDict()
-    )
-    forced_use.freeze()
-    pkg_bashrc = ()
-    pkg_use_force = pkg_use_mask = ImmutableDict()
-    pkg_provided = system = profile_set = ((), ())
 
 
 class ProfileStack:

--- a/src/pkgcore/ebuild/repo_objs.py
+++ b/src/pkgcore/ebuild/repo_objs.py
@@ -1060,7 +1060,7 @@ class RepoConfig(syncable.tree, klass.ImmutableInstance, metaclass=WeakInstMeta)
     @klass.jit_attr
     def base_profile(self):
         pms_strict = "pms" in self.profile_formats
-        return profiles.EmptyRootNode(self.profiles_base, pms_strict=pms_strict)
+        return profiles.ProfileNode(self.profiles_base, pms_strict=pms_strict)
 
     @klass.jit_attr
     def eapi(self):


### PR DESCRIPTION
I don't understand why is `RepoConfig.base_profile` instantiated as [`EmptyRootNode`](https://pkgcore.github.io/pkgcore/api/pkgcore.ebuild.profiles.html#pkgcore.ebuild.profiles.EmptyRootNode). Why couldn't it be [`ProfileNode`](https://pkgcore.github.io/pkgcore/api/pkgcore.ebuild.profiles.html#pkgcore.ebuild.profiles.ProfileNode) instead?

Using `EmptyRootNode` leads to unexpected (to me) behavior. For example, ::guru has `profiles/package.use.mask` but `UnconfiguredTree.config.base_profile.pkg_use_mask` is empty.